### PR TITLE
Init project, routing & themes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,8 @@
 ## Changes
-- 
+- Describe the changes made and reference the issue (e.g. Closes #<issue_number>)
 
 ## Checklist
+- [ ] Linked to an issue (e.g. Closes #6)
 - [ ] Tested on Android
 - [ ] Tested on iOS
 - [ ] Docs updated (README/Comments)

--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -63,3 +63,8 @@ jobs:
         run: flutter pub get
       - name: Build debug APK
         run: flutter build apk --debug
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-debug-apk
+          path: build/app/outputs/flutter-apk/app-debug.apk

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,6 @@ app.*.symbols
 .python-version
 .gclient_previous_custom_vars
 .gclient_previous_sync_commits
+
+# Ensure pubspec.lock is never ignored (explicit override)
+!pubspec.lock

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'screens/home_screen.dart';
+import 'screens/settings_screen.dart';
+
+final GoRouter appRouter = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(
+      path: '/',
+      name: 'home',
+      builder: (context, state) => const HomeScreen(),
+    ),
+    GoRoute(
+      path: '/settings',
+      name: 'settings',
+      builder: (context, state) => const SettingsScreen(),
+    ),
+  ],
+  errorBuilder: (context, state) => Scaffold(
+    appBar: AppBar(title: const Text('Not found')),
+    body: Center(child: Text(state.error.toString())),
+  ),
+);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Habits')),
+      body: Center(
+        child: ElevatedButton.icon(
+          onPressed: () => context.push('/settings'),
+          icon: const Icon(Icons.settings),
+          label: const Text('Settings'),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {},
+        tooltip: 'Add habit',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          ListTile(
+            title: Text('Theme'),
+            subtitle: Text('Follows system (Light/Dark)'),
+            leading: Icon(Icons.brightness_6),
+          ),
+          SizedBox(height: 8),
+          ListTile(
+            title: Text('About'),
+            subtitle: Text('Habit Tracker MVP'),
+            leading: Icon(Icons.info_outline),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static ThemeData light = ThemeData(
+    brightness: Brightness.light,
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF4F46E5)), // indigo-ish
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+  );
+
+  static ThemeData dark = ThemeData(
+    brightness: Brightness.dark,
+    useMaterial3: true,
+    colorScheme: ColorScheme.fromSeed(
+      seedColor: const Color(0xFF4F46E5),
+      brightness: Brightness.dark,
+    ),
+    visualDensity: VisualDensity.adaptivePlatformDensity,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,15 +66,28 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: c752e2d08d088bf83742cb05bf83003f3e9d276ff1519b5c92f9d5e60e5ddd23
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.2.4"
   leak_tracker:
     dependency: transitive
     description:
@@ -103,10 +116,18 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: a5e2b223cb7c9c8efdc663ef484fdd95bb243bff242ef5b13e26883547fce9a0
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.0.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -210,4 +231,4 @@ packages:
     version: "15.0.2"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  go_router: ^16.2.4
+  
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
@@ -44,7 +45,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION

### ✨ What’s new
- Initial app setup with routing and theming
- Added router configuration (`app_router.dart`) using `go_router`
- Added Material 3 light & dark themes (`app_theme.dart`)
- Created starter screens: Home + Settings
- Updated `main.dart` to wire themes and router

### 🧩 Why
Establishes navigation and consistent app styling for future features (Onboarding, Habit CRUD, Notifications).

### ✅ Testing
- App launches to Home
- Navigation to Settings works
- Dark/light mode follows system

Closes #6
