### PR TITLE
Fix nightly skip logic & artifact naming (Closes #29)

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -33,10 +33,10 @@ jobs:
               repo: context.repo.repo,
               workflow_id: context.workflow,
               event: 'schedule',
-              status: 'success',
-              per_page: 1
+              per_page: 5
             });
-            core.setOutput('sha', data.workflow_runs[0]?.head_sha || '')
+            const lastSuccess = data.workflow_runs.find(run => run.conclusion === 'success');
+            core.setOutput('sha', lastSuccess?.head_sha || '')
       - name: Compare
         id: compare
         uses: actions/github-script@v7


### PR DESCRIPTION
This PR:\n- Updates nightly skip-check to only skip if last build succeeded and no new commits.\n- Aligns nightly artifact naming with PR CI (version + build number).\nCloses #29.