### PR TITLE
Phase 0 - CI macOS restriction (Closes #39)

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -74,7 +74,7 @@ jobs:
   analyze-test:
     if: needs.skip-check.outputs.should_skip != 'true'
     needs: skip-check
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -117,7 +117,7 @@ jobs:
   android-release:
     if: needs.skip-check.outputs.should_skip != 'true'
     needs: analyze-test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
This PR adjusts the CI workflow:
- Ensures Android builds run only on Ubuntu.
- Ensures iOS builds are reserved for macOS runners.
- Keeps Phase 0 Play upload pipeline consistent.

Closes #39.