### PR TITLE
Phase 0 - Fix Play whatsNew naming & releaseName (Related to #39)

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -244,7 +244,7 @@ jobs:
         run: |
           URL="${{ steps.gh_release.outputs.url }}"
           mkdir -p whatsnew
-          echo "$URL" > whatsnew/en-US.txt
+          echo "$URL" > whatsnew/whatsnew-en-US.txt
 
       - name: Authenticate to Google Cloud (WIF)
         if: github.event_name == 'schedule' || github.event.inputs.manual_release == 'true'
@@ -265,3 +265,4 @@ jobs:
           track: internal
           status: completed
           whatsNewDirectory: whatsnew
+          releaseName: v${{ env.APP_VERSION_NAME }}.${{ env.APP_BUILD_NUMBER }}


### PR DESCRIPTION
Use BCP47-compliant file naming for whatsNew (whatsnew-en-US) and set a clear releaseName for internal track.\n\nRelated to #39.