### PR TITLE
CI: keyless Firebase upload via CLI (WIF) + keystore restore hardening

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -297,11 +297,17 @@ jobs:
           service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
           create_credentials_file: true
 
-      - name: Upload APK to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1
-        with:
-          appId: ${{ env.FIREBASE_APP_ID }}
-          serviceCredentialsFile: ${{ steps.fb_auth.outputs.credentials_file_path }}
-          groups: ${{ vars.FIREBASE_TESTERS_GROUP || 'internal' }}
-          file: ${{ env.APK_OUT }}
-          releaseNotes: "${{ env.FLAVOR_CAP }} ${{ github.event_name == 'schedule' && 'Nightly' || 'Manual' }} v${{ env.APP_VERSION_NAME }}.${{ env.APP_BUILD_NUMBER }} on ${{ env.DATE }}"
+      - name: Distribute to Firebase App Distribution (CLI)
+        shell: bash
+        env:
+          FIREBASE_APP_ID: ${{ env.FIREBASE_APP_ID }}
+          APK_OUT: ${{ env.APK_OUT }}
+          FLAVOR_CAP: ${{ env.FLAVOR_CAP }}
+          APP_VERSION_NAME: ${{ env.APP_VERSION_NAME }}
+          APP_BUILD_NUMBER: ${{ env.APP_BUILD_NUMBER }}
+          DATE: ${{ env.DATE }}
+          FIREBASE_TESTERS_GROUP: ${{ vars.FIREBASE_TESTERS_GROUP || 'internal' }}
+        run: |
+          npm install -g firebase-tools@13
+          RELEASE_NOTES="${FLAVOR_CAP} $([[ "${GITHUB_EVENT_NAME}" == "schedule" ]] && echo "Nightly" || echo "Manual") v${APP_VERSION_NAME}.${APP_BUILD_NUMBER} on ${DATE}"
+          firebase appdistribution:distribute "$APK_OUT" --app "$FIREBASE_APP_ID" --groups "${FIREBASE_TESTERS_GROUP}" --release-notes "$RELEASE_NOTES" 


### PR DESCRIPTION
This PR:
- Switches Firebase App Distribution upload to CLI with WIF (no SA keys).
- Hardens keystore restore: explicit secret mapping, path guard, base64 decode.
- Aligns nightly/prod pipelines for consistency and reliability.