### PR TITLE
feat: instrument firebase analytics

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 android.useAndroidX=true
 android.enableJetifier=true

--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,24 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+
 import 'screens/home_screen.dart';
 import 'screens/settings_screen.dart';
 
-final GoRouter appRouter = GoRouter(
-  initialLocation: '/',
-  routes: [
-    GoRoute(
-      path: '/',
-      name: 'home',
-      builder: (context, state) => const HomeScreen(),
+GoRouter createAppRouter({List<NavigatorObserver> observers = const []}) {
+  return GoRouter(
+    initialLocation: '/',
+    observers: observers,
+    routes: [
+      GoRoute(
+        path: '/',
+        name: 'home',
+        builder: (context, state) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: '/settings',
+        name: 'settings',
+        builder: (context, state) => const SettingsScreen(),
+      ),
+    ],
+    errorBuilder: (context, state) => Scaffold(
+      appBar: AppBar(title: const Text('Not found')),
+      body: Center(child: Text(state.error.toString())),
     ),
-    GoRoute(
-      path: '/settings',
-      name: 'settings',
-      builder: (context, state) => const SettingsScreen(),
-    ),
-  ],
-  errorBuilder: (context, state) => Scaffold(
-    appBar: AppBar(title: const Text('Not found')),
-    body: Center(child: Text(state.error.toString())),
-  ),
-);
+  );
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,16 +3,19 @@ import 'dart:isolate';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'app_config.dart';
-import 'app_router.dart';
-import 'theme/app_theme.dart';
-
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_analytics/observer.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:go_router/go_router.dart';
 
 import 'firebase_options_dev.dart' as dev;
 import 'firebase_options_staging.dart' as stg;
 import 'firebase_options_prod.dart' as prod;
+import 'app_config.dart';
+import 'app_router.dart';
+import 'services/analytics_service.dart';
+import 'theme/app_theme.dart';
 
 FirebaseOptions get firebaseOptions {
   if (AppConfig.isProd) return prod.DefaultFirebaseOptions.currentPlatform;
@@ -24,20 +27,27 @@ FirebaseOptions get firebaseOptions {
 // Locally (default) this is false. In CI PR builds, pass:
 //   --dart-define=FIREBASE_ENABLED=true
 // In **release** builds, Firebase is always enabled regardless of the flag.
-const bool kFirebaseEnabled =
-    bool.fromEnvironment('FIREBASE_ENABLED', defaultValue: false);
+const bool kFirebaseEnabled = bool.fromEnvironment(
+  'FIREBASE_ENABLED',
+  defaultValue: false,
+);
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  FirebaseAnalyticsObserver? analyticsObserver;
+
   if (kFirebaseEnabled || kReleaseMode) {
     try {
-      await Firebase.initializeApp(
-        options: firebaseOptions,
-      );
+      await Firebase.initializeApp(options: firebaseOptions);
 
       // Enable Crashlytics collection for CI/test builds
       await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+
+      final analytics = FirebaseAnalytics.instance;
+      await AnalyticsService.configure(analytics);
+      await AnalyticsService.logAppOpen();
+      analyticsObserver = AnalyticsService.observer;
 
       // Forward Flutter framework errors
       FlutterError.onError = (FlutterErrorDetails details) {
@@ -73,11 +83,17 @@ Future<void> main() async {
     FlutterError.onError = FlutterError.presentError;
   }
 
-  runApp(const HabitTrackerApp());
+  final router = createAppRouter(
+    observers: [if (analyticsObserver != null) analyticsObserver!],
+  );
+
+  runApp(HabitTrackerApp(router: router));
 }
 
 class HabitTrackerApp extends StatelessWidget {
-  const HabitTrackerApp({super.key});
+  const HabitTrackerApp({super.key, required this.router});
+
+  final GoRouter router;
 
   @override
   Widget build(BuildContext context) {
@@ -86,7 +102,7 @@ class HabitTrackerApp extends StatelessWidget {
       title: 'Habit Tracker${AppConfig.nameSuffix}',
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
-      routerConfig: appRouter,
+      routerConfig: router,
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_analytics/observer.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:go_router/go_router.dart';
@@ -83,9 +82,12 @@ Future<void> main() async {
     FlutterError.onError = FlutterError.presentError;
   }
 
-  final router = createAppRouter(
-    observers: [if (analyticsObserver != null) analyticsObserver!],
-  );
+  final observers = <NavigatorObserver>[];
+  if (analyticsObserver != null) {
+    observers.add(analyticsObserver);
+  }
+
+  final router = createAppRouter(observers: observers);
 
   runApp(HabitTrackerApp(router: router));
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+
+import '../services/analytics_service.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -11,13 +15,18 @@ class HomeScreen extends StatelessWidget {
       body: Center(
         child: ElevatedButton.icon(
           key: const Key('btn_settings'),
-          onPressed: () => context.push('/settings'),
+          onPressed: () {
+            unawaited(AnalyticsService.logEvent('open_settings_tap'));
+            context.push('/settings');
+          },
           icon: const Icon(Icons.settings),
           label: const Text('Settings'),
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {},
+        onPressed: () {
+          unawaited(AnalyticsService.logEvent('add_habit_tap'));
+        },
         tooltip: 'Add habit',
         child: const Icon(Icons.add),
       ),

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,5 +1,4 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_analytics/observer.dart';
 
 /// Thin wrapper around [FirebaseAnalytics] so the UI can safely
 /// no-op when analytics is disabled.

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,41 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_analytics/observer.dart';
+
+/// Thin wrapper around [FirebaseAnalytics] so the UI can safely
+/// no-op when analytics is disabled.
+class AnalyticsService {
+  const AnalyticsService._();
+
+  static FirebaseAnalytics? _analytics;
+  static FirebaseAnalyticsObserver? _observer;
+
+  static bool get enabled => _analytics != null;
+  static FirebaseAnalyticsObserver? get observer => _observer;
+
+  static Future<void> configure(FirebaseAnalytics analytics) async {
+    _analytics = analytics;
+    _observer = FirebaseAnalyticsObserver(analytics: analytics);
+    await analytics.setAnalyticsCollectionEnabled(true);
+  }
+
+  static Future<void> logAppOpen() async {
+    await _analytics?.logAppOpen();
+  }
+
+  static Future<void> logEvent(
+    String name, {
+    Map<String, Object>? parameters,
+  }) async {
+    await _analytics?.logEvent(name: name, parameters: parameters);
+  }
+
+  static Future<void> logScreenView(
+    String screenName, {
+    String? screenClass,
+  }) async {
+    await _analytics?.logScreenView(
+      screenName: screenName,
+      screenClass: screenClass ?? screenName,
+    );
+  }
+}

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/foundation.dart';
 
 /// Thin wrapper around [FirebaseAnalytics] so the UI can safely
 /// no-op when analytics is disabled.
@@ -23,9 +24,16 @@ class AnalyticsService {
 
   static Future<void> logEvent(
     String name, {
-    Map<String, Object>? parameters,
+    Map<String, Object?>? parameters,
   }) async {
-    await _analytics?.logEvent(name: name, parameters: parameters);
+    final sanitized = parameters == null
+        ? null
+        : Map<String, Object>.fromEntries(
+            parameters.entries
+                .where((entry) => entry.value != null)
+                .map((entry) => MapEntry(entry.key, entry.value!)),
+          );
+    await _analytics?.logEvent(name: name, parameters: sanitized);
   }
 
   static Future<void> logScreenView(
@@ -36,5 +44,11 @@ class AnalyticsService {
       screenName: screenName,
       screenClass: screenClass ?? screenName,
     );
+  }
+
+  @visibleForTesting
+  static void reset() {
+    _analytics = null;
+    _observer = null;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  mocktail: ^1.0.3
 
 # Flutter configuration
 flutter:

--- a/test/analytics_service_test.dart
+++ b/test/analytics_service_test.dart
@@ -1,0 +1,68 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/services/analytics_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, Object?>{});
+  });
+
+  setUp(AnalyticsService.reset);
+
+  test('configure wires analytics and enables collection', () async {
+    final analytics = _MockFirebaseAnalytics();
+
+    when(
+      () => analytics.setAnalyticsCollectionEnabled(true),
+    ).thenAnswer((_) async {});
+    when(() => analytics.logAppOpen()).thenAnswer((_) async {});
+    when(
+      () => analytics.logEvent(
+        name: any(named: 'name'),
+        parameters: any(named: 'parameters'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => analytics.logScreenView(
+        screenName: any(named: 'screenName'),
+        screenClass: any(named: 'screenClass'),
+      ),
+    ).thenAnswer((_) async {});
+
+    await AnalyticsService.configure(analytics);
+
+    expect(AnalyticsService.enabled, isTrue);
+    expect(AnalyticsService.observer, isNotNull);
+
+    await AnalyticsService.logAppOpen();
+    await AnalyticsService.logEvent('test_event', parameters: {'foo': 'bar'});
+    await AnalyticsService.logScreenView('home', screenClass: 'HomeScreen');
+
+    verify(() => analytics.setAnalyticsCollectionEnabled(true)).called(1);
+    verify(() => analytics.logAppOpen()).called(1);
+    verify(
+      () => analytics.logEvent(name: 'test_event', parameters: {'foo': 'bar'}),
+    ).called(1);
+    verify(
+      () => analytics.logScreenView(
+        screenName: 'home',
+        screenClass: 'HomeScreen',
+      ),
+    ).called(1);
+  });
+
+  test('log calls are safe when analytics is disabled', () async {
+    expect(AnalyticsService.enabled, isFalse);
+    expect(AnalyticsService.observer, isNull);
+
+    await AnalyticsService.logAppOpen();
+    await AnalyticsService.logEvent('noop');
+    await AnalyticsService.logScreenView('noop');
+
+    expect(AnalyticsService.enabled, isFalse);
+    expect(AnalyticsService.observer, isNull);
+  });
+}

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -23,5 +23,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Settings'), findsOneWidget);
+
+    final backButton = find.byTooltip('Back');
+    await tester.tap(backButton);
+    await tester.pumpAndSettle();
+
+    final fab = find.byType(FloatingActionButton);
+    expect(fab, findsOneWidget);
+    await tester.tap(fab);
+    await tester.pump();
+  });
+
+  testWidgets('shows not found page for unknown routes', (
+    WidgetTester tester,
+  ) async {
+    final router = createAppRouter();
+
+    await tester.pumpWidget(
+      MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light,
+        darkTheme: AppTheme.dark,
+        routerConfig: router,
+      ),
+    );
+
+    router.go('/missing');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not found'), findsOneWidget);
   });
 }

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -5,12 +5,14 @@ import 'package:habit_tracker/theme/app_theme.dart';
 
 void main() {
   testWidgets('navigates from Home to Settings', (WidgetTester tester) async {
-    await tester.pumpWidget(MaterialApp.router(
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.light,
-      darkTheme: AppTheme.dark,
-      routerConfig: appRouter,
-    ));
+    await tester.pumpWidget(
+      MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        theme: AppTheme.light,
+        darkTheme: AppTheme.dark,
+        routerConfig: createAppRouter(),
+      ),
+    );
 
     await tester.pumpAndSettle();
     expect(find.text('Habits'), findsOneWidget);


### PR DESCRIPTION
## Summary
- initialize Firebase Analytics alongside Crashlytics when telemetry is enabled
- route analytics through a shared service and hook the observer into GoRouter
- emit basic interaction events and disable Gradle config cache to unblock release builds

## Testing
- flutter test
