### PR TITLE
feat: add analytics consent flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@ import 'dart:isolate';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:go_router/go_router.dart';
@@ -13,7 +12,8 @@ import 'firebase_options_staging.dart' as stg;
 import 'firebase_options_prod.dart' as prod;
 import 'app_config.dart';
 import 'app_router.dart';
-import 'services/analytics_service.dart';
+import 'state/telemetry_controller.dart';
+import 'state/telemetry_provider.dart';
 import 'theme/app_theme.dart';
 
 FirebaseOptions get firebaseOptions {
@@ -34,77 +34,177 @@ const bool kFirebaseEnabled = bool.fromEnvironment(
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  FirebaseAnalyticsObserver? analyticsObserver;
-
-  if (kFirebaseEnabled || kReleaseMode) {
+  final enableFirebase = kFirebaseEnabled || kReleaseMode;
+  if (enableFirebase) {
     try {
       await Firebase.initializeApp(options: firebaseOptions);
-
-      // Enable Crashlytics collection for CI/test builds
-      await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
-
-      final analytics = FirebaseAnalytics.instance;
-      await AnalyticsService.configure(analytics);
-      await AnalyticsService.logAppOpen();
-      analyticsObserver = AnalyticsService.observer;
-
-      // Forward Flutter framework errors
-      FlutterError.onError = (FlutterErrorDetails details) {
-        FlutterError.presentError(details);
-        FirebaseCrashlytics.instance.recordFlutterFatalError(details);
-      };
-
-      // Uncaught errors from the engine / platform
-      PlatformDispatcher.instance.onError = (error, stack) {
-        FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
-        return true;
-      };
-
-      // Uncaught async errors
-      Isolate.current.addErrorListener(
-        RawReceivePort((pair) async {
-          final List<dynamic> errorAndStacktrace = pair;
-          await FirebaseCrashlytics.instance.recordError(
-            errorAndStacktrace.first,
-            errorAndStacktrace.last as StackTrace,
-            fatal: true,
-          );
-        }).sendPort,
-      );
     } catch (e, st) {
-      // If configs are missing (e.g., local dev), fail gracefully
       debugPrint('Firebase init skipped/failed: $e');
       debugPrintStack(stackTrace: st);
-      FlutterError.onError = FlutterError.presentError;
     }
+  }
+
+  final telemetryController = TelemetryController(
+    enableFirebase: enableFirebase,
+  );
+  await telemetryController.initialize();
+
+  if (enableFirebase) {
+    // Forward Flutter framework errors
+    FlutterError.onError = (FlutterErrorDetails details) {
+      FlutterError.presentError(details);
+      FirebaseCrashlytics.instance.recordFlutterFatalError(details);
+    };
+
+    // Uncaught errors from the engine / platform
+    PlatformDispatcher.instance.onError = (error, stack) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+      return true;
+    };
+
+    // Uncaught async errors
+    Isolate.current.addErrorListener(
+      RawReceivePort((pair) async {
+        final List<dynamic> errorAndStacktrace = pair;
+        await FirebaseCrashlytics.instance.recordError(
+          errorAndStacktrace.first,
+          errorAndStacktrace.last as StackTrace,
+          fatal: true,
+        );
+      }).sendPort,
+    );
   } else {
-    // Local dev: no Firebase/Crashlytics
     FlutterError.onError = FlutterError.presentError;
   }
 
   final observers = <NavigatorObserver>[];
-  if (analyticsObserver != null) {
-    observers.add(analyticsObserver);
+  final observer = telemetryController.analyticsObserver;
+  if (observer != null) {
+    observers.add(observer);
   }
 
   final router = createAppRouter(observers: observers);
 
-  runApp(HabitTrackerApp(router: router));
+  runApp(
+    HabitTrackerApp(router: router, telemetryController: telemetryController),
+  );
 }
 
 class HabitTrackerApp extends StatelessWidget {
-  const HabitTrackerApp({super.key, required this.router});
+  const HabitTrackerApp({
+    super.key,
+    required this.router,
+    required this.telemetryController,
+  });
 
   final GoRouter router;
+  final TelemetryController telemetryController;
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      debugShowCheckedModeBanner: false,
-      title: 'Habit Tracker${AppConfig.nameSuffix}',
-      theme: AppTheme.light,
-      darkTheme: AppTheme.dark,
-      routerConfig: router,
+    return TelemetryProvider(
+      controller: telemetryController,
+      child: MaterialApp.router(
+        debugShowCheckedModeBanner: false,
+        title: 'Habit Tracker${AppConfig.nameSuffix}',
+        theme: AppTheme.light,
+        darkTheme: AppTheme.dark,
+        routerConfig: router,
+        builder: (context, child) => _ConsentPromptOverlay(child: child),
+      ),
     );
+  }
+}
+
+class _ConsentPromptOverlay extends StatefulWidget {
+  const _ConsentPromptOverlay({required this.child});
+
+  final Widget? child;
+
+  @override
+  State<_ConsentPromptOverlay> createState() => _ConsentPromptOverlayState();
+}
+
+class _ConsentPromptOverlayState extends State<_ConsentPromptOverlay> {
+  TelemetryController? _controller;
+  bool _dialogShown = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final controller = TelemetryProvider.of(context);
+    if (!identical(controller, _controller)) {
+      _controller?.removeListener(_handleControllerChanged);
+      _controller = controller..addListener(_handleControllerChanged);
+      _maybeShowDialog();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller?.removeListener(_handleControllerChanged);
+    super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    _maybeShowDialog();
+  }
+
+  void _maybeShowDialog() {
+    final controller = _controller;
+    if (controller == null) return;
+    if (_dialogShown) return;
+    if (!controller.isLoaded) return;
+    if (controller.hasRecordedDecision) return;
+
+    _dialogShown = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return AlertDialog(
+            title: const Text('Share Anonymous Usage Data?'),
+            content: const Text(
+              'Help us improve Habit Tracker by sharing anonymized usage metrics '
+              'and crash reports. You can change this later in Settings.',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () async {
+                  await TelemetryProvider.of(context).updateConsent(false);
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                },
+                child: const Text('Not now'),
+              ),
+              FilledButton(
+                onPressed: () async {
+                  await TelemetryProvider.of(context).updateConsent(true);
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+                },
+                child: const Text('Share'),
+              ),
+            ],
+          );
+        },
+      ).whenComplete(() {
+        if (!mounted) return;
+        // If the user dismissed via system back, keep showing next frame.
+        if (!_controller!.hasRecordedDecision) {
+          _dialogShown = false;
+          _maybeShowDialog();
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child ?? const SizedBox.shrink();
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,27 +1,48 @@
 import 'package:flutter/material.dart';
 
+import '../state/telemetry_provider.dart';
+
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final telemetry = TelemetryProvider.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
-        padding: const EdgeInsets.all(16),
-        children: const [
-          ListTile(
-            title: Text('Theme'),
-            subtitle: Text('Follows system (Light/Dark)'),
-            leading: Icon(Icons.brightness_6),
-          ),
-          SizedBox(height: 8),
-          ListTile(
-            title: Text('About'),
-            subtitle: Text('Habit Tracker MVP'),
-            leading: Icon(Icons.info_outline),
-          ),
-        ],
+      body: AnimatedBuilder(
+        animation: telemetry,
+        builder: (context, _) {
+          final consent = telemetry.isConsentGranted;
+          final loaded = telemetry.isLoaded;
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              SwitchListTile.adaptive(
+                title: const Text('Share anonymous usage & crash reports'),
+                subtitle: const Text(
+                  'Helps us spot issues faster. You can change this at any time.',
+                ),
+                value: consent,
+                onChanged: loaded
+                    ? (value) => telemetry.updateConsent(value)
+                    : null,
+              ),
+              const SizedBox(height: 16),
+              const ListTile(
+                title: Text('Theme'),
+                subtitle: Text('Follows system (Light/Dark)'),
+                leading: Icon(Icons.brightness_6),
+              ),
+              const SizedBox(height: 8),
+              const ListTile(
+                title: Text('About'),
+                subtitle: Text('Habit Tracker MVP'),
+                leading: Icon(Icons.info_outline),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/services/consent_service.dart
+++ b/lib/services/consent_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ConsentService {
+  const ConsentService._();
+
+  static const _key = 'analytics_consent';
+  static bool _hasLoaded = false;
+  static bool _consentGranted = false;
+  static bool _hasDecision = false;
+
+  static bool get hasLoaded => _hasLoaded;
+  static bool get consentGranted => _consentGranted;
+  static bool get hasRecordedDecision => _hasDecision;
+
+  static Future<void> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    _hasDecision = prefs.containsKey(_key);
+    _consentGranted = prefs.getBool(_key) ?? false;
+    _hasLoaded = true;
+  }
+
+  static Future<void> setConsent(bool granted) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, granted);
+    _consentGranted = granted;
+    _hasDecision = true;
+  }
+
+  @visibleForTesting
+  static Future<void> reset() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+    _hasLoaded = false;
+    _consentGranted = false;
+    _hasDecision = false;
+  }
+}

--- a/lib/state/telemetry_controller.dart
+++ b/lib/state/telemetry_controller.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+import '../services/analytics_service.dart';
+import '../services/consent_service.dart';
+
+class TelemetryController extends ChangeNotifier {
+  TelemetryController({
+    required this.enableFirebase,
+    FirebaseAnalytics? analytics,
+    FirebaseCrashlytics? crashlytics,
+  }) : _analytics = analytics ?? FirebaseAnalytics.instance,
+       _crashlytics = crashlytics ?? FirebaseCrashlytics.instance;
+
+  final bool enableFirebase;
+  final FirebaseAnalytics _analytics;
+  final FirebaseCrashlytics _crashlytics;
+
+  bool _loaded = false;
+  bool _consent = false;
+  bool _hasDecision = false;
+
+  bool get isLoaded => _loaded;
+  bool get isConsentGranted => _consent;
+  bool get hasRecordedDecision => _hasDecision;
+
+  NavigatorObserver? get analyticsObserver => AnalyticsService.observer;
+
+  Future<void> initialize() async {
+    await ConsentService.load();
+    _consent = ConsentService.consentGranted;
+    _hasDecision = ConsentService.hasRecordedDecision;
+
+    if (enableFirebase) {
+      await _applyTelemetryState(_consent);
+    }
+
+    _loaded = true;
+    notifyListeners();
+  }
+
+  Future<void> updateConsent(bool granted) async {
+    await ConsentService.setConsent(granted);
+    _consent = granted;
+    _hasDecision = true;
+
+    if (enableFirebase) {
+      await _applyTelemetryState(granted);
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> _applyTelemetryState(bool granted) async {
+    await _crashlytics.setCrashlyticsCollectionEnabled(granted);
+    await _analytics.setAnalyticsCollectionEnabled(granted);
+
+    if (granted) {
+      if (!AnalyticsService.enabled) {
+        await AnalyticsService.configure(_analytics);
+      }
+      await AnalyticsService.logAppOpen();
+    }
+  }
+}

--- a/lib/state/telemetry_provider.dart
+++ b/lib/state/telemetry_provider.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/widgets.dart';
+
+import 'telemetry_controller.dart';
+
+class TelemetryProvider extends InheritedNotifier<TelemetryController> {
+  const TelemetryProvider({
+    super.key,
+    required TelemetryController controller,
+    required super.child,
+  }) : super(notifier: controller);
+
+  static TelemetryController of(BuildContext context) {
+    final provider = context
+        .dependOnInheritedWidgetOfExactType<TelemetryProvider>();
+    assert(provider != null, 'TelemetryProvider not found in context');
+    return provider!.notifier!;
+  }
+
+  @override
+  bool updateShouldNotify(
+    covariant InheritedNotifier<TelemetryController> oldWidget,
+  ) {
+    return oldWidget.notifier != notifier;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   firebase_analytics:
     dependency: "direct main"
     description:
@@ -240,6 +256,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -248,6 +296,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0b0f98d535319cb5cdd4f65783c2a54ee6d417a2f093dbb18be3e36e4c3d181f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.14"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -325,6 +429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_core: ^3.8.0
   firebase_analytics: ^11.3.0
   firebase_crashlytics: ^4.1.0
+  shared_preferences: ^2.3.2
   
 dev_dependencies:
   flutter_test:

--- a/test/analytics_service_test.dart
+++ b/test/analytics_service_test.dart
@@ -54,6 +54,32 @@ void main() {
     ).called(1);
   });
 
+  test('logEvent strips null parameters before forwarding', () async {
+    final analytics = _MockFirebaseAnalytics();
+
+    when(
+      () => analytics.setAnalyticsCollectionEnabled(true),
+    ).thenAnswer((_) async {});
+    when(
+      () => analytics.logEvent(
+        name: any(named: 'name'),
+        parameters: any(named: 'parameters'),
+      ),
+    ).thenAnswer((_) async {});
+
+    await AnalyticsService.configure(analytics);
+
+    await AnalyticsService.logEvent(
+      'test_event',
+      parameters: {'keep': 'value', 'drop': null},
+    );
+
+    verify(
+      () =>
+          analytics.logEvent(name: 'test_event', parameters: {'keep': 'value'}),
+    ).called(1);
+  });
+
   test('log calls are safe when analytics is disabled', () async {
     expect(AnalyticsService.enabled, isFalse);
     expect(AnalyticsService.observer, isNull);

--- a/test/consent_service_test.dart
+++ b/test/consent_service_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/services/consent_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await ConsentService.reset();
+  });
+
+  test('load defaults to no decision and false consent', () async {
+    await ConsentService.load();
+
+    expect(ConsentService.hasLoaded, isTrue);
+    expect(ConsentService.hasRecordedDecision, isFalse);
+    expect(ConsentService.consentGranted, isFalse);
+  });
+
+  test('setConsent persists and marks decision', () async {
+    await ConsentService.load();
+    await ConsentService.setConsent(true);
+
+    expect(ConsentService.consentGranted, isTrue);
+    expect(ConsentService.hasRecordedDecision, isTrue);
+
+    // Reload from storage to verify persistence
+    await ConsentService.load();
+    expect(ConsentService.consentGranted, isTrue);
+    expect(ConsentService.hasRecordedDecision, isTrue);
+  });
+}

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -1,16 +1,79 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:habit_tracker/app_router.dart';
+import 'package:habit_tracker/services/analytics_service.dart';
+import 'package:habit_tracker/state/telemetry_controller.dart';
+import 'package:habit_tracker/state/telemetry_provider.dart';
 import 'package:habit_tracker/theme/app_theme.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAnalytics extends Mock implements FirebaseAnalytics {}
+
+class _MockCrashlytics extends Mock implements FirebaseCrashlytics {}
 
 void main() {
+  late TelemetryController controller;
+  late _MockAnalytics analytics;
+  late _MockCrashlytics crashlytics;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'analytics_consent': true});
+    AnalyticsService.reset();
+
+    analytics = _MockAnalytics();
+    crashlytics = _MockCrashlytics();
+
+    when(
+      () => analytics.setAnalyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+    when(() => analytics.logAppOpen()).thenAnswer((_) async {});
+    when(
+      () => analytics.logEvent(
+        name: any(named: 'name'),
+        parameters: any(named: 'parameters'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => analytics.logScreenView(
+        screenName: any(named: 'screenName'),
+        screenClass: any(named: 'screenClass'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => crashlytics.setCrashlyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+
+    controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+    await controller.initialize();
+  });
+
+  tearDown(() {
+    controller.dispose();
+  });
+
   testWidgets('navigates from Home to Settings', (WidgetTester tester) async {
+    final router = createAppRouter(
+      observers: [
+        if (controller.analyticsObserver != null) controller.analyticsObserver!,
+      ],
+    );
+
     await tester.pumpWidget(
-      MaterialApp.router(
-        debugShowCheckedModeBanner: false,
-        theme: AppTheme.light,
-        darkTheme: AppTheme.dark,
-        routerConfig: createAppRouter(),
+      TelemetryProvider(
+        controller: controller,
+        child: MaterialApp.router(
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.light,
+          darkTheme: AppTheme.dark,
+          routerConfig: router,
+        ),
       ),
     );
 
@@ -37,14 +100,21 @@ void main() {
   testWidgets('shows not found page for unknown routes', (
     WidgetTester tester,
   ) async {
-    final router = createAppRouter();
+    final router = createAppRouter(
+      observers: [
+        if (controller.analyticsObserver != null) controller.analyticsObserver!,
+      ],
+    );
 
     await tester.pumpWidget(
-      MaterialApp.router(
-        debugShowCheckedModeBanner: false,
-        theme: AppTheme.light,
-        darkTheme: AppTheme.dark,
-        routerConfig: router,
+      TelemetryProvider(
+        controller: controller,
+        child: MaterialApp.router(
+          debugShowCheckedModeBanner: false,
+          theme: AppTheme.light,
+          darkTheme: AppTheme.dark,
+          routerConfig: router,
+        ),
       ),
     );
 

--- a/test/settings_screen_test.dart
+++ b/test/settings_screen_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/screens/settings_screen.dart';
+import 'package:habit_tracker/services/analytics_service.dart';
+import 'package:habit_tracker/services/consent_service.dart';
+import 'package:habit_tracker/state/telemetry_controller.dart';
+import 'package:habit_tracker/state/telemetry_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+
+class _MockAnalytics extends Mock implements FirebaseAnalytics {}
+
+class _MockCrashlytics extends Mock implements FirebaseCrashlytics {}
+
+void main() {
+  late TelemetryController controller;
+  late _MockAnalytics analytics;
+  late _MockCrashlytics crashlytics;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await ConsentService.reset();
+    AnalyticsService.reset();
+
+    analytics = _MockAnalytics();
+    crashlytics = _MockCrashlytics();
+    when(
+      () => analytics.setAnalyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+    when(() => analytics.logAppOpen()).thenAnswer((_) async {});
+    when(
+      () => crashlytics.setCrashlyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+
+    controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+    await controller.initialize();
+  });
+
+  tearDown(() {
+    controller.dispose();
+  });
+
+  testWidgets('toggle updates consent state', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      TelemetryProvider(
+        controller: controller,
+        child: const MaterialApp(home: SettingsScreen()),
+      ),
+    );
+
+    await tester.pump();
+
+    final toggle = find.byType(SwitchListTile);
+    expect(toggle, findsOneWidget);
+
+    expect(controller.isConsentGranted, isFalse);
+
+    await tester.tap(toggle);
+    await tester.pumpAndSettle();
+
+    expect(controller.isConsentGranted, isTrue);
+  });
+}

--- a/test/telemetry_controller_test.dart
+++ b/test/telemetry_controller_test.dart
@@ -1,0 +1,118 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/services/analytics_service.dart';
+import 'package:habit_tracker/services/consent_service.dart';
+import 'package:habit_tracker/state/telemetry_controller.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAnalytics extends Mock implements FirebaseAnalytics {}
+
+class _MockCrashlytics extends Mock implements FirebaseCrashlytics {}
+
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await ConsentService.reset();
+    AnalyticsService.reset();
+  });
+
+  _MockAnalytics buildAnalyticsMock() {
+    final analytics = _MockAnalytics();
+    when(
+      () => analytics.setAnalyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+    when(() => analytics.logAppOpen()).thenAnswer((_) async {});
+    when(
+      () => analytics.logEvent(
+        name: any(named: 'name'),
+        parameters: any(named: 'parameters'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => analytics.logScreenView(
+        screenName: any(named: 'screenName'),
+        screenClass: any(named: 'screenClass'),
+      ),
+    ).thenAnswer((_) async {});
+    return analytics;
+  }
+
+  _MockCrashlytics buildCrashlyticsMock() {
+    final crashlytics = _MockCrashlytics();
+    when(
+      () => crashlytics.setCrashlyticsCollectionEnabled(any()),
+    ).thenAnswer((_) async {});
+    return crashlytics;
+  }
+
+  test('initialize keeps telemetry disabled without consent', () async {
+    final analytics = buildAnalyticsMock();
+    final crashlytics = buildCrashlyticsMock();
+
+    final controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+
+    await controller.initialize();
+
+    expect(controller.isLoaded, isTrue);
+    expect(controller.hasRecordedDecision, isFalse);
+    expect(controller.isConsentGranted, isFalse);
+    expect(AnalyticsService.enabled, isFalse);
+
+    verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(false)).called(1);
+  });
+
+  test('initialize enables telemetry when consent stored', () async {
+    SharedPreferences.setMockInitialValues({'analytics_consent': true});
+
+    final analytics = buildAnalyticsMock();
+    final crashlytics = buildCrashlyticsMock();
+
+    final controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+
+    await controller.initialize();
+
+    expect(controller.isConsentGranted, isTrue);
+    expect(controller.hasRecordedDecision, isTrue);
+    expect(AnalyticsService.enabled, isTrue);
+    expect(controller.analyticsObserver, isNotNull);
+
+    verify(() => analytics.setAnalyticsCollectionEnabled(true)).called(2);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(true)).called(1);
+  });
+
+  test('updateConsent toggles telemetry at runtime', () async {
+    final analytics = buildAnalyticsMock();
+    final crashlytics = buildCrashlyticsMock();
+
+    final controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+    await controller.initialize();
+
+    await controller.updateConsent(true);
+    expect(controller.isConsentGranted, isTrue);
+    verify(() => analytics.setAnalyticsCollectionEnabled(true)).called(2);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(true)).called(1);
+
+    clearInteractions(analytics);
+    clearInteractions(crashlytics);
+
+    await controller.updateConsent(false);
+    expect(controller.isConsentGranted, isFalse);
+    verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(false)).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- gate analytics and crash reporting behind stored user consent with a blocking first-run prompt and a settings toggle
- orchestrate telemetry via consent-aware controller/provider and persist decisions in shared preferences
- cover consent logic with unit/widget tests and sanitize analytics payloads to satisfy coverage gating

## Testing
- flutter analyze
- flutter test --coverage

Related to #50