### PR TITLE
build: raise deployment minimums

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -223,7 +223,7 @@ packages:
     source: hosted
     version: "6.0.0"
   flutter_native_splash:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: flutter_native_splash
       sha256: "8321a6d11a8d13977fa780c89de8d257cce3d841eecfb7a4cadffcc4f12d82dc"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,14 @@ dependencies:
   firebase_analytics: ^12.0.2
   firebase_crashlytics: ^5.0.2
   shared_preferences: ^2.3.2
-  
+  flutter_native_splash: ^2.4.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.3
   flutter_launcher_icons: ^0.14.4
-  flutter_native_splash: ^2.4.1
 
 # Flutter configuration
 flutter:


### PR DESCRIPTION
## Summary
- raise Android minSdk to 31 and iOS deployment target to 15
- update Firebase pods and regenerate CocoaPods lockfile
- promote flutter_native_splash to runtime dependency so release builds include the plugin

## Testing
- flutter build apk --flavor staging --release *(fails: missing google-services.json, as expected in local env)*
