### PR TITLE
Integrate Riverpod for telemetry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "dart.flutterSdkPath": ".fvm/flutter_sdk"
+  "dart.flutterSdkPath": ".fvm/versions/3.35.4"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
@@ -90,10 +91,14 @@ Future<void> main() async {
   );
 
   runApp(
-    HabitTrackerApp(
-      router: router,
-      telemetryController: telemetryController,
-      rootNavigatorKey: rootNavigatorKey,
+    ProviderScope(
+      overrides: [
+        telemetryControllerProvider.overrideWith((ref) => telemetryController),
+      ],
+      child: HabitTrackerApp(
+        router: router,
+        rootNavigatorKey: rootNavigatorKey,
+      ),
     ),
   );
 }
@@ -102,34 +107,27 @@ class HabitTrackerApp extends StatelessWidget {
   const HabitTrackerApp({
     super.key,
     required this.router,
-    required this.telemetryController,
     required this.rootNavigatorKey,
   });
 
   final GoRouter router;
-  final TelemetryController telemetryController;
   final GlobalKey<NavigatorState> rootNavigatorKey;
 
   @override
   Widget build(BuildContext context) {
-    return TelemetryProvider(
-      controller: telemetryController,
-      child: MaterialApp.router(
-        debugShowCheckedModeBanner: false,
-        title: 'Habit Tracker${AppConfig.nameSuffix}',
-        theme: AppTheme.light,
-        darkTheme: AppTheme.dark,
-        routerConfig: router,
-        builder: (context, child) => _ConsentPromptOverlay(
-          navigatorKey: rootNavigatorKey,
-          child: child,
-        ),
-      ),
+    return MaterialApp.router(
+      debugShowCheckedModeBanner: false,
+      title: 'Habit Tracker${AppConfig.nameSuffix}',
+      theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
+      routerConfig: router,
+      builder: (context, child) =>
+          _ConsentPromptOverlay(navigatorKey: rootNavigatorKey, child: child),
     );
   }
 }
 
-class _ConsentPromptOverlay extends StatefulWidget {
+class _ConsentPromptOverlay extends ConsumerStatefulWidget {
   const _ConsentPromptOverlay({
     required this.child,
     required this.navigatorKey,
@@ -139,22 +137,27 @@ class _ConsentPromptOverlay extends StatefulWidget {
   final GlobalKey<NavigatorState> navigatorKey;
 
   @override
-  State<_ConsentPromptOverlay> createState() => _ConsentPromptOverlayState();
+  ConsumerState<_ConsentPromptOverlay> createState() =>
+      _ConsentPromptOverlayState();
 }
 
-class _ConsentPromptOverlayState extends State<_ConsentPromptOverlay> {
+class _ConsentPromptOverlayState extends ConsumerState<_ConsentPromptOverlay> {
   TelemetryController? _controller;
   bool _dialogShown = false;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    final controller = TelemetryProvider.of(context);
-    if (!identical(controller, _controller)) {
-      _controller?.removeListener(_handleControllerChanged);
-      _controller = controller..addListener(_handleControllerChanged);
+  void initState() {
+    super.initState();
+    ref.listen<TelemetryController>(telemetryControllerProvider, (
+      previous,
+      controller,
+    ) {
+      if (!identical(controller, _controller)) {
+        _controller?.removeListener(_handleControllerChanged);
+        _controller = controller..addListener(_handleControllerChanged);
+      }
       _maybeShowDialog();
-    }
+    }, fireImmediately: true);
   }
 
   @override
@@ -193,7 +196,9 @@ class _ConsentPromptOverlayState extends State<_ConsentPromptOverlay> {
             actions: [
               TextButton(
                 onPressed: () async {
-                  await TelemetryProvider.of(context).updateConsent(false);
+                  await ref
+                      .read(telemetryControllerProvider)
+                      .updateConsent(false);
                   if (navigatorContext.mounted) {
                     Navigator.of(navigatorContext).pop();
                   }
@@ -202,7 +207,9 @@ class _ConsentPromptOverlayState extends State<_ConsentPromptOverlay> {
               ),
               FilledButton(
                 onPressed: () async {
-                  await TelemetryProvider.of(context).updateConsent(true);
+                  await ref
+                      .read(telemetryControllerProvider)
+                      .updateConsent(true);
                   if (navigatorContext.mounted) {
                     Navigator.of(navigatorContext).pop();
                   }
@@ -215,7 +222,8 @@ class _ConsentPromptOverlayState extends State<_ConsentPromptOverlay> {
       ).whenComplete(() {
         if (!mounted) return;
         // If the user dismissed via system back, keep showing next frame.
-        if (!_controller!.hasRecordedDecision) {
+        final controller = _controller;
+        if (controller != null && !controller.hasRecordedDecision) {
           _dialogShown = false;
           _maybeShowDialog();
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -144,26 +144,35 @@ class _ConsentPromptOverlay extends ConsumerStatefulWidget {
 class _ConsentPromptOverlayState extends ConsumerState<_ConsentPromptOverlay> {
   TelemetryController? _controller;
   bool _dialogShown = false;
+  ProviderSubscription<TelemetryController>? _subscription;
 
   @override
   void initState() {
     super.initState();
-    ref.listen<TelemetryController>(telemetryControllerProvider, (
-      previous,
-      controller,
-    ) {
-      if (!identical(controller, _controller)) {
-        _controller?.removeListener(_handleControllerChanged);
-        _controller = controller..addListener(_handleControllerChanged);
-      }
-      _maybeShowDialog();
-    }, fireImmediately: true);
+    _attachController(ref.read(telemetryControllerProvider));
+    _maybeShowDialog();
+
+    _subscription = ref.listenManual<TelemetryController>(
+      telemetryControllerProvider,
+      (previous, controller) {
+        _attachController(controller);
+        _maybeShowDialog();
+      },
+    );
   }
 
   @override
   void dispose() {
     _controller?.removeListener(_handleControllerChanged);
+    _subscription?.close();
     super.dispose();
+  }
+
+  void _attachController(TelemetryController controller) {
+    if (!identical(controller, _controller)) {
+      _controller?.removeListener(_handleControllerChanged);
+      _controller = controller..addListener(_handleControllerChanged);
+    }
   }
 
   void _handleControllerChanged() {
@@ -178,7 +187,14 @@ class _ConsentPromptOverlayState extends ConsumerState<_ConsentPromptOverlay> {
     if (controller.hasRecordedDecision) return;
 
     final navigatorContext = widget.navigatorKey.currentContext;
-    if (navigatorContext == null) return;
+    if (navigatorContext == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) {
+          _maybeShowDialog();
+        }
+      });
+      return;
+    }
 
     _dialogShown = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,48 +1,45 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../state/telemetry_provider.dart';
 
-class SettingsScreen extends StatelessWidget {
+class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final telemetry = TelemetryProvider.of(context);
+  Widget build(BuildContext context, WidgetRef ref) {
+    final telemetry = ref.watch(telemetryControllerProvider);
+    final consent = telemetry.isConsentGranted;
+    final loaded = telemetry.isLoaded;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: AnimatedBuilder(
-        animation: telemetry,
-        builder: (context, _) {
-          final consent = telemetry.isConsentGranted;
-          final loaded = telemetry.isLoaded;
-          return ListView(
-            padding: const EdgeInsets.all(16),
-            children: [
-              SwitchListTile.adaptive(
-                title: const Text('Share anonymous usage & crash reports'),
-                subtitle: const Text(
-                  'Helps us spot issues faster. You can change this at any time.',
-                ),
-                value: consent,
-                onChanged: loaded
-                    ? (value) => telemetry.updateConsent(value)
-                    : null,
-              ),
-              const SizedBox(height: 16),
-              const ListTile(
-                title: Text('Theme'),
-                subtitle: Text('Follows system (Light/Dark)'),
-                leading: Icon(Icons.brightness_6),
-              ),
-              const SizedBox(height: 8),
-              const ListTile(
-                title: Text('About'),
-                subtitle: Text('Habit Tracker MVP'),
-                leading: Icon(Icons.info_outline),
-              ),
-            ],
-          );
-        },
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SwitchListTile.adaptive(
+            title: const Text('Share anonymous usage & crash reports'),
+            subtitle: const Text(
+              'Helps us spot issues faster. You can change this at any time.',
+            ),
+            value: consent,
+            onChanged: loaded
+                ? (value) => telemetry.updateConsent(value)
+                : null,
+          ),
+          const SizedBox(height: 16),
+          const ListTile(
+            title: Text('Theme'),
+            subtitle: Text('Follows system (Light/Dark)'),
+            leading: Icon(Icons.brightness_6),
+          ),
+          const SizedBox(height: 8),
+          const ListTile(
+            title: Text('About'),
+            subtitle: Text('Habit Tracker MVP'),
+            leading: Icon(Icons.info_outline),
+          ),
+        ],
       ),
     );
   }

--- a/lib/state/telemetry_provider.dart
+++ b/lib/state/telemetry_provider.dart
@@ -1,25 +1,14 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'telemetry_controller.dart';
 
-class TelemetryProvider extends InheritedNotifier<TelemetryController> {
-  const TelemetryProvider({
-    super.key,
-    required TelemetryController controller,
-    required super.child,
-  }) : super(notifier: controller);
-
-  static TelemetryController of(BuildContext context) {
-    final provider = context
-        .dependOnInheritedWidgetOfExactType<TelemetryProvider>();
-    assert(provider != null, 'TelemetryProvider not found in context');
-    return provider!.notifier!;
-  }
-
-  @override
-  bool updateShouldNotify(
-    covariant InheritedNotifier<TelemetryController> oldWidget,
-  ) {
-    return oldWidget.notifier != notifier;
-  }
-}
+/// Riverpod provider for the global [TelemetryController].
+///
+/// The controller is initialized in `main.dart` and injected via
+/// [ProviderScope.overrides] so that widget tests can supply their own
+/// instances easily.
+final telemetryControllerProvider = ChangeNotifierProvider<TelemetryController>(
+  (ref) => throw UnimplementedError(
+    'Override telemetryControllerProvider before reading it.',
+  ),
+);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -230,6 +230,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.6"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -408,6 +416,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -485,6 +501,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   go_router: ^16.2.4
+  flutter_riverpod: ^2.5.1
   cupertino_icons: ^1.0.8
   firebase_core: ^4.1.1
   firebase_analytics: ^12.0.2

--- a/test/consent_prompt_overlay_test.dart
+++ b/test/consent_prompt_overlay_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:habit_tracker/main.dart';
+import 'package:habit_tracker/services/consent_service.dart';
+import 'package:habit_tracker/state/telemetry_controller.dart';
+import 'package:habit_tracker/state/telemetry_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  late TelemetryController controller;
+  late GoRouter router;
+  late GlobalKey<NavigatorState> navigatorKey;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await ConsentService.reset();
+
+    controller = TelemetryController(enableFirebase: false);
+    await controller.initialize();
+
+    navigatorKey = GlobalKey<NavigatorState>();
+    router = GoRouter(
+      navigatorKey: navigatorKey,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const SizedBox.shrink(),
+        ),
+      ],
+    );
+  });
+
+  tearDown(() {
+    router.dispose();
+  });
+
+  Widget buildApp() {
+    return ProviderScope(
+      overrides: [
+        telemetryControllerProvider.overrideWith((ref) => controller),
+      ],
+      child: HabitTrackerApp(router: router, rootNavigatorKey: navigatorKey),
+    );
+  }
+
+  testWidgets('dismisses consent dialog when opting out', (tester) async {
+    await tester.pumpWidget(buildApp());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Share Anonymous Usage Data?'), findsOneWidget);
+
+    await tester.tap(find.text('Not now'));
+    await tester.pumpAndSettle();
+
+    expect(controller.hasRecordedDecision, isTrue);
+    expect(controller.isConsentGranted, isFalse);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+
+  testWidgets('records consent when user accepts', (tester) async {
+    await tester.pumpWidget(buildApp());
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Share'));
+    await tester.pumpAndSettle();
+
+    expect(controller.hasRecordedDecision, isTrue);
+    expect(controller.isConsentGranted, isTrue);
+    expect(find.byType(AlertDialog), findsNothing);
+  });
+}

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:habit_tracker/app_router.dart';
 import 'package:habit_tracker/services/analytics_service.dart';
@@ -54,10 +55,6 @@ void main() {
     await controller.initialize();
   });
 
-  tearDown(() {
-    controller.dispose();
-  });
-
   testWidgets('navigates from Home to Settings', (WidgetTester tester) async {
     final router = createAppRouter(
       observers: [
@@ -66,8 +63,10 @@ void main() {
     );
 
     await tester.pumpWidget(
-      TelemetryProvider(
-        controller: controller,
+      ProviderScope(
+        overrides: [
+          telemetryControllerProvider.overrideWith((ref) => controller),
+        ],
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,
           theme: AppTheme.light,
@@ -107,8 +106,10 @@ void main() {
     );
 
     await tester.pumpWidget(
-      TelemetryProvider(
-        controller: controller,
+      ProviderScope(
+        overrides: [
+          telemetryControllerProvider.overrideWith((ref) => controller),
+        ],
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,
           theme: AppTheme.light,

--- a/test/settings_screen_test.dart
+++ b/test/settings_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:habit_tracker/screens/settings_screen.dart';
 import 'package:habit_tracker/services/analytics_service.dart';
@@ -42,14 +43,12 @@ void main() {
     await controller.initialize();
   });
 
-  tearDown(() {
-    controller.dispose();
-  });
-
   testWidgets('toggle updates consent state', (WidgetTester tester) async {
     await tester.pumpWidget(
-      TelemetryProvider(
-        controller: controller,
+      ProviderScope(
+        overrides: [
+          telemetryControllerProvider.overrideWith((ref) => controller),
+        ],
         child: const MaterialApp(home: SettingsScreen()),
       ),
     );


### PR DESCRIPTION
## Summary
- add flutter_riverpod dependency and provider wiring
- wrap app entry with ProviderScope and migrate consent flow
- update tests to use Riverpod overrides

## Testing
- flutter test