### PR TITLE
Add remote release notes, notifications settings, and HTML rendering

### DIFF
--- a/docs/release-notes/1.0.0.0.html
+++ b/docs/release-notes/1.0.0.0.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Release Notes v1.0.0.0</title>
+  </head>
+  <body>
+    <h1>Release Notes v1.0.0.0</h1>
+    <p><em>Placeholder:</em> Detailed release notes for version 1.0.0.0 will appear here.</p>
+  </body>
+</html>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -129,6 +129,8 @@ PODS:
     - nanopb/encode (= 3.30910.0)
   - nanopb/decode (3.30910.0)
   - nanopb/encode (3.30910.0)
+  - package_info_plus (0.4.5):
+    - Flutter
   - PromisesObjC (2.4.0)
   - PromisesSwift (2.4.0):
     - PromisesObjC (= 2.4.0)
@@ -142,6 +144,7 @@ DEPENDENCIES:
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
 
 SPEC REPOS:
@@ -174,6 +177,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_native_splash:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
 
@@ -197,6 +202,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -1,5 +1,9 @@
 class AppConfig {
   static const flavor = String.fromEnvironment('FLAVOR', defaultValue: 'dev');
+  static const contentBaseUrl = String.fromEnvironment(
+    'CONTENT_BASE_URL',
+    defaultValue: 'https://dewiest-aviator.github.io/habit_tracker',
+  );
 
   static bool get isDev => flavor == 'dev';
   static bool get isStaging => flavor == 'staging';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,10 @@ import 'app_config.dart';
 import 'app_router.dart';
 import 'state/telemetry_controller.dart';
 import 'state/telemetry_provider.dart';
+import 'state/theme_controller.dart';
+import 'state/theme_provider.dart';
+import 'state/notification_settings_controller.dart';
+import 'state/notification_settings_provider.dart';
 import 'theme/app_theme.dart';
 
 FirebaseOptions get firebaseOptions {
@@ -50,6 +54,12 @@ Future<void> main() async {
     enableFirebase: enableFirebase,
   );
   await telemetryController.initialize();
+
+  final themeController = ThemeController();
+  await themeController.load();
+
+  final notificationSettingsController = NotificationSettingsController();
+  await notificationSettingsController.load();
 
   if (enableFirebase) {
     // Forward Flutter framework errors
@@ -94,6 +104,10 @@ Future<void> main() async {
     ProviderScope(
       overrides: [
         telemetryControllerProvider.overrideWith((ref) => telemetryController),
+        themeControllerProvider.overrideWith((ref) => themeController),
+        notificationSettingsProvider.overrideWith(
+          (ref) => notificationSettingsController,
+        ),
       ],
       child: HabitTrackerApp(
         router: router,
@@ -103,7 +117,7 @@ Future<void> main() async {
   );
 }
 
-class HabitTrackerApp extends StatelessWidget {
+class HabitTrackerApp extends ConsumerWidget {
   const HabitTrackerApp({
     super.key,
     required this.router,
@@ -114,12 +128,15 @@ class HabitTrackerApp extends StatelessWidget {
   final GlobalKey<NavigatorState> rootNavigatorKey;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeControllerProvider).themeMode;
+
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       title: 'Habit Tracker${AppConfig.nameSuffix}',
       theme: AppTheme.light,
       darkTheme: AppTheme.dark,
+      themeMode: themeMode,
       routerConfig: router,
       builder: (context, child) =>
           _ConsentPromptOverlay(navigatorKey: rootNavigatorKey, child: child),

--- a/lib/screens/privacy_policy_screen.dart
+++ b/lib/screens/privacy_policy_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/remote_content_provider.dart';
+
+class PrivacyPolicyScreen extends ConsumerWidget {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final content = ref.watch(remoteContentProvider('privacy-policy'));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Privacy Policy')),
+      body: content.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, _) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: Center(
+            child: Text(
+              'Failed to load privacy policy: $error',
+              textAlign: TextAlign.center,
+            ),
+          ),
+        ),
+        data: (body) => Padding(
+          padding: const EdgeInsets.all(16),
+          child: SingleChildScrollView(
+            child: Html(
+              data: body,
+              style: {
+                'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/release_notes_screen.dart
+++ b/lib/screens/release_notes_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/app_info_provider.dart';
+import '../state/remote_content_provider.dart';
+
+class ReleaseNotesScreen extends ConsumerWidget {
+  const ReleaseNotesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appInfo = ref.watch(appInfoProvider);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Release Notes')),
+      body: appInfo.when(
+        loading: () => const _CenteredProgress(),
+        error: (error, _) =>
+            _ErrorContent(message: 'Failed to load app info: $error'),
+        data: (info) {
+          final versionKey = '${info.version}.${info.buildNumber}';
+          final notes = ref.watch(
+            remoteContentProvider('release-notes/$versionKey'),
+          );
+
+          return notes.when(
+            loading: () => const _CenteredProgress(),
+            error: (error, _) =>
+                _ErrorContent(message: 'Failed to load release notes: $error'),
+            data: (content) => _ContentView(content: content),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ContentView extends StatelessWidget {
+  const _ContentView({required this.content});
+
+  final String content;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: SingleChildScrollView(
+        child: Html(
+          data: content,
+          style: {
+            'body': Style(margin: Margins.zero, padding: HtmlPaddings.zero),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _CenteredProgress extends StatelessWidget {
+  const _CenteredProgress();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+}
+
+class _ErrorContent extends StatelessWidget {
+  const _ErrorContent({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Center(child: Text(message, textAlign: TextAlign.center)),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,7 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../state/app_info_provider.dart';
+import '../state/notification_settings_provider.dart';
 import '../state/telemetry_provider.dart';
+import '../state/theme_provider.dart';
+import 'privacy_policy_screen.dart';
+import 'release_notes_screen.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
@@ -9,38 +14,250 @@ class SettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final telemetry = ref.watch(telemetryControllerProvider);
-    final consent = telemetry.isConsentGranted;
+    final analyticsEnabled = telemetry.isAnalyticsEnabled;
+    final crashEnabled = telemetry.isCrashEnabled;
     final loaded = telemetry.isLoaded;
+    final themeController = ref.watch(themeControllerProvider);
+    final themeMode = themeController.themeMode;
+    const themeModes = [ThemeMode.system, ThemeMode.light, ThemeMode.dark];
+    final appInfo = ref.watch(appInfoProvider);
+    final notificationSettings = ref.watch(notificationSettingsProvider);
+    final notificationsLoaded = notificationSettings.hasLoaded;
+    final notificationsEnabled = notificationSettings.enabled;
+    final reminderTime = notificationSettings.reminderTime;
+    final formattedReminderTime = MaterialLocalizations.of(
+      context,
+    ).formatTimeOfDay(reminderTime);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          SwitchListTile.adaptive(
-            title: const Text('Share anonymous usage & crash reports'),
-            subtitle: const Text(
-              'Helps us spot issues faster. You can change this at any time.',
+          const _SectionHeader('Privacy & Data'),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SwitchListTile.adaptive(
+                  key: const Key('switch_analytics_consent'),
+                  title: const Text('Share anonymous usage analytics'),
+                  subtitle: const Text(
+                    'Helps us understand which features are most useful.',
+                  ),
+                  value: analyticsEnabled,
+                  onChanged: loaded
+                      ? (value) => telemetry.updateAnalyticsConsent(value)
+                      : null,
+                ),
+                const Divider(height: 0),
+                SwitchListTile.adaptive(
+                  key: const Key('switch_crash_consent'),
+                  title: const Text('Share crash reports'),
+                  subtitle: const Text(
+                    'Sends anonymized crash logs so we can fix issues faster.',
+                  ),
+                  value: crashEnabled,
+                  onChanged: loaded
+                      ? (value) => telemetry.updateCrashConsent(value)
+                      : null,
+                ),
+              ],
             ),
-            value: consent,
-            onChanged: loaded
-                ? (value) => telemetry.updateConsent(value)
-                : null,
           ),
-          const SizedBox(height: 16),
-          const ListTile(
-            title: Text('Theme'),
-            subtitle: Text('Follows system (Light/Dark)'),
-            leading: Icon(Icons.brightness_6),
+          const SizedBox(height: 24),
+          const _SectionHeader('Notifications'),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                SwitchListTile.adaptive(
+                  key: const Key('switch_notifications_enabled'),
+                  title: const Text('Daily reminder notifications'),
+                  subtitle: const Text(
+                    'Receive a helpful nudge to complete today’s habits.',
+                  ),
+                  value: notificationsEnabled,
+                  onChanged: notificationsLoaded
+                      ? (value) => notificationSettings.setEnabled(value)
+                      : null,
+                ),
+                const Divider(height: 0),
+                ListTile(
+                  key: const Key('tile_notification_time'),
+                  enabled: notificationsEnabled,
+                  leading: const Icon(Icons.access_time),
+                  title: const Text('Reminder time'),
+                  subtitle: Text('Currently $formattedReminderTime'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: (!notificationsLoaded || !notificationsEnabled)
+                      ? null
+                      : () async {
+                          final picked = await showTimePicker(
+                            context: context,
+                            initialTime: reminderTime,
+                          );
+                          if (picked != null) {
+                            await notificationSettings.setReminderTime(picked);
+                          }
+                        },
+                ),
+              ],
+            ),
           ),
-          const SizedBox(height: 8),
-          const ListTile(
-            title: Text('About'),
-            subtitle: Text('Habit Tracker MVP'),
-            leading: Icon(Icons.info_outline),
+          const SizedBox(height: 24),
+          const _SectionHeader('Appearance'),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  DropdownButtonFormField<ThemeMode>(
+                    initialValue: themeMode,
+                    decoration: const InputDecoration(
+                      labelText: 'Theme mode',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: themeModes
+                        .map(
+                          (mode) => DropdownMenuItem<ThemeMode>(
+                            value: mode,
+                            child: Text(_themeLabel(mode)),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) {
+                      if (value != null) {
+                        themeController.setThemeMode(value);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    _themeDescription(themeMode),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          const _SectionHeader('About'),
+          const SizedBox(height: 12),
+          _SettingsCard(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                appInfo.when(
+                  data: (info) => ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                    leading: const Icon(Icons.info_outline),
+                    title: Text(info.appName),
+                    subtitle: Text(
+                      'v${info.version}.${info.buildNumber} - version name and build number',
+                    ),
+                  ),
+                  loading: () => const ListTile(
+                    contentPadding: EdgeInsets.symmetric(horizontal: 16),
+                    leading: SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                    title: Text('Loading app info...'),
+                  ),
+                  error: (error, _) => ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+                    leading: const Icon(Icons.info_outline),
+                    title: const Text('Habit Tracker'),
+                    subtitle: Text('Version unavailable: $error'),
+                  ),
+                ),
+                const Divider(height: 0),
+                ListTile(
+                  leading: const Icon(Icons.article_outlined),
+                  title: const Text('Release notes'),
+                  subtitle: const Text('See what changed in each version'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (context) => const ReleaseNotesScreen(),
+                      ),
+                    );
+                  },
+                ),
+                const Divider(height: 0),
+                ListTile(
+                  leading: const Icon(Icons.privacy_tip_outlined),
+                  title: const Text('Privacy policy'),
+                  subtitle: const Text('How we handle your data'),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (context) => const PrivacyPolicyScreen(),
+                      ),
+                    );
+                  },
+                ),
+              ],
+            ),
           ),
         ],
       ),
     );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      label,
+      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+    );
+  }
+}
+
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(clipBehavior: Clip.antiAlias, child: child);
+  }
+}
+
+String _themeLabel(ThemeMode mode) {
+  switch (mode) {
+    case ThemeMode.system:
+      return 'Use system setting';
+    case ThemeMode.light:
+      return 'Light mode';
+    case ThemeMode.dark:
+      return 'Dark mode';
+  }
+}
+
+String _themeDescription(ThemeMode mode) {
+  switch (mode) {
+    case ThemeMode.system:
+      return 'Automatically follow device appearance';
+    case ThemeMode.light:
+      return 'Always use a light theme';
+    case ThemeMode.dark:
+      return 'Always use a dark theme';
   }
 }

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -46,9 +46,11 @@ class AnalyticsService {
     );
   }
 
-  @visibleForTesting
-  static void reset() {
+  static void disable() {
     _analytics = null;
     _observer = null;
   }
+
+  @visibleForTesting
+  static void reset() => disable();
 }

--- a/lib/services/consent_service.dart
+++ b/lib/services/consent_service.dart
@@ -4,35 +4,74 @@ import 'package:shared_preferences/shared_preferences.dart';
 class ConsentService {
   const ConsentService._();
 
-  static const _key = 'analytics_consent';
+  static const _analyticsKey = 'analytics_consent';
+  static const _crashKey = 'crash_consent';
+
   static bool _hasLoaded = false;
-  static bool _consentGranted = false;
-  static bool _hasDecision = false;
+  static bool _analyticsConsentGranted = false;
+  static bool _crashConsentGranted = false;
+  static bool _hasAnalyticsDecision = false;
+  static bool _hasCrashDecision = false;
 
   static bool get hasLoaded => _hasLoaded;
-  static bool get consentGranted => _consentGranted;
-  static bool get hasRecordedDecision => _hasDecision;
+  static bool get analyticsConsentGranted => _analyticsConsentGranted;
+  static bool get crashConsentGranted => _crashConsentGranted;
+  static bool get consentGranted =>
+      _analyticsConsentGranted && _crashConsentGranted;
+  static bool get hasAnalyticsDecision => _hasAnalyticsDecision;
+  static bool get hasCrashDecision => _hasCrashDecision;
+  static bool get hasRecordedDecision =>
+      _hasAnalyticsDecision && _hasCrashDecision;
 
   static Future<void> load() async {
     final prefs = await SharedPreferences.getInstance();
-    _hasDecision = prefs.containsKey(_key);
-    _consentGranted = prefs.getBool(_key) ?? false;
+
+    _hasAnalyticsDecision = prefs.containsKey(_analyticsKey);
+    _analyticsConsentGranted = prefs.getBool(_analyticsKey) ?? false;
+
+    if (prefs.containsKey(_crashKey)) {
+      _hasCrashDecision = true;
+      _crashConsentGranted = prefs.getBool(_crashKey) ?? false;
+    } else {
+      // Migrate legacy single-consent value to crash setting.
+      _crashConsentGranted = _analyticsConsentGranted;
+      _hasCrashDecision = _hasAnalyticsDecision;
+      if (_hasCrashDecision) {
+        await prefs.setBool(_crashKey, _crashConsentGranted);
+      }
+    }
+
     _hasLoaded = true;
   }
 
   static Future<void> setConsent(bool granted) async {
+    await setAnalyticsConsent(granted);
+    await setCrashConsent(granted);
+  }
+
+  static Future<void> setAnalyticsConsent(bool granted) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_key, granted);
-    _consentGranted = granted;
-    _hasDecision = true;
+    await prefs.setBool(_analyticsKey, granted);
+    _analyticsConsentGranted = granted;
+    _hasAnalyticsDecision = true;
+  }
+
+  static Future<void> setCrashConsent(bool granted) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_crashKey, granted);
+    _crashConsentGranted = granted;
+    _hasCrashDecision = true;
   }
 
   @visibleForTesting
   static Future<void> reset() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_key);
+    await prefs.remove(_analyticsKey);
+    await prefs.remove(_crashKey);
     _hasLoaded = false;
-    _consentGranted = false;
-    _hasDecision = false;
+    _analyticsConsentGranted = false;
+    _crashConsentGranted = false;
+    _hasAnalyticsDecision = false;
+    _hasCrashDecision = false;
   }
 }

--- a/lib/state/app_info_provider.dart
+++ b/lib/state/app_info_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+final appInfoProvider = FutureProvider<PackageInfo>((ref) async {
+  return PackageInfo.fromPlatform();
+});

--- a/lib/state/notification_settings_controller.dart
+++ b/lib/state/notification_settings_controller.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NotificationSettingsController extends ChangeNotifier {
+  NotificationSettingsController({SharedPreferences? preferences})
+      : _providedPrefs = preferences;
+
+  static const _enabledKey = 'notifications_enabled';
+  static const _timeKey = 'notifications_time';
+
+  final SharedPreferences? _providedPrefs;
+  SharedPreferences? _prefs;
+
+  bool _hasLoaded = false;
+  bool _enabled = false;
+  TimeOfDay _time = const TimeOfDay(hour: 8, minute: 0);
+
+  bool get hasLoaded => _hasLoaded;
+  bool get enabled => _enabled;
+  TimeOfDay get reminderTime => _time;
+
+  Future<void> load() async {
+    final prefs = _providedPrefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
+
+    _enabled = prefs.getBool(_enabledKey) ?? false;
+    final stored = prefs.getString(_timeKey);
+    if (stored != null) {
+      final parts = stored.split(':');
+      if (parts.length == 2) {
+        final hour = int.tryParse(parts[0]);
+        final minute = int.tryParse(parts[1]);
+        if (hour != null && minute != null) {
+          _time = TimeOfDay(hour: hour, minute: minute);
+        }
+      }
+    }
+
+    _hasLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> setEnabled(bool value) async {
+    if (_enabled == value && _hasLoaded) return;
+    _enabled = value;
+    _hasLoaded = true;
+    notifyListeners();
+
+    final prefs = _prefs ?? _providedPrefs ?? await SharedPreferences.getInstance();
+    await prefs.setBool(_enabledKey, value);
+    _prefs = prefs;
+  }
+
+  Future<void> setReminderTime(TimeOfDay time) async {
+    if (_time == time && _hasLoaded) return;
+    _time = time;
+    _hasLoaded = true;
+    notifyListeners();
+
+    final prefs = _prefs ?? _providedPrefs ?? await SharedPreferences.getInstance();
+    final formatted = '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+    await prefs.setString(_timeKey, formatted);
+    _prefs = prefs;
+  }
+}

--- a/lib/state/notification_settings_provider.dart
+++ b/lib/state/notification_settings_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'notification_settings_controller.dart';
+
+final notificationSettingsProvider =
+    ChangeNotifierProvider<NotificationSettingsController>((ref) {
+  throw UnimplementedError(
+    'Override notificationSettingsProvider before reading it.',
+  );
+});

--- a/lib/state/remote_content_provider.dart
+++ b/lib/state/remote_content_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+import '../app_config.dart';
+
+final httpClientProvider = Provider<http.Client>((ref) {
+  final client = http.Client();
+  ref.onDispose(client.close);
+  return client;
+});
+
+final remoteContentProvider = FutureProvider.family.autoDispose<String, String>((
+  ref,
+  endpoint,
+) async {
+  final client = ref.watch(httpClientProvider);
+  final baseUrl = AppConfig.contentBaseUrl;
+  final normalizedEndpoint = endpoint.startsWith('/')
+      ? endpoint.substring(1)
+      : endpoint;
+  final uri = Uri.parse('$baseUrl/$normalizedEndpoint');
+  final response = await client.get(uri);
+  if (response.statusCode != 200) {
+    throw Exception(
+      'Failed to load content (${response.statusCode}) from ${uri.toString()}',
+    );
+  }
+  return response.body;
+});

--- a/lib/state/telemetry_controller.dart
+++ b/lib/state/telemetry_controller.dart
@@ -11,34 +11,45 @@ class TelemetryController extends ChangeNotifier {
     required this.enableFirebase,
     FirebaseAnalytics? analytics,
     FirebaseCrashlytics? crashlytics,
-  })  : _analytics = enableFirebase
-            ? analytics ?? FirebaseAnalytics.instance
-            : null,
-        _crashlytics = enableFirebase
-            ? crashlytics ?? FirebaseCrashlytics.instance
-            : null;
+  }) : _analytics = enableFirebase
+           ? analytics ?? FirebaseAnalytics.instance
+           : null,
+       _crashlytics = enableFirebase
+           ? crashlytics ?? FirebaseCrashlytics.instance
+           : null;
 
   final bool enableFirebase;
   final FirebaseAnalytics? _analytics;
   final FirebaseCrashlytics? _crashlytics;
 
   bool _loaded = false;
-  bool _consent = false;
-  bool _hasDecision = false;
+  bool _analyticsConsent = false;
+  bool _crashConsent = false;
+  bool _hasAnalyticsDecision = false;
+  bool _hasCrashDecision = false;
 
   bool get isLoaded => _loaded;
-  bool get isConsentGranted => _consent;
-  bool get hasRecordedDecision => _hasDecision;
+  bool get isAnalyticsEnabled => _analyticsConsent;
+  bool get isCrashEnabled => _crashConsent;
+  bool get isConsentGranted => _analyticsConsent && _crashConsent;
+  bool get hasAnalyticsDecision => _hasAnalyticsDecision;
+  bool get hasCrashDecision => _hasCrashDecision;
+  bool get hasRecordedDecision => _hasAnalyticsDecision && _hasCrashDecision;
 
   NavigatorObserver? get analyticsObserver => AnalyticsService.observer;
 
   Future<void> initialize() async {
     await ConsentService.load();
-    _consent = ConsentService.consentGranted;
-    _hasDecision = ConsentService.hasRecordedDecision;
+    _analyticsConsent = ConsentService.analyticsConsentGranted;
+    _crashConsent = ConsentService.crashConsentGranted;
+    _hasAnalyticsDecision = ConsentService.hasAnalyticsDecision;
+    _hasCrashDecision = ConsentService.hasCrashDecision;
 
     if (enableFirebase) {
-      await _applyTelemetryState(_consent);
+      await _applyAnalyticsState(_analyticsConsent);
+      await _applyCrashState(_crashConsent);
+    } else if (!_analyticsConsent) {
+      AnalyticsService.disable();
     }
 
     _loaded = true;
@@ -46,32 +57,62 @@ class TelemetryController extends ChangeNotifier {
   }
 
   Future<void> updateConsent(bool granted) async {
-    await ConsentService.setConsent(granted);
-    _consent = granted;
-    _hasDecision = true;
-
-    if (enableFirebase) {
-      await _applyTelemetryState(granted);
-    }
-
+    await _setAnalyticsConsent(granted);
+    await _setCrashConsent(granted);
     notifyListeners();
   }
 
-  Future<void> _applyTelemetryState(bool granted) async {
-    final crashlytics = _crashlytics;
-    if (crashlytics != null) {
-      await crashlytics.setCrashlyticsCollectionEnabled(granted);
+  Future<void> updateAnalyticsConsent(bool granted) async {
+    await _setAnalyticsConsent(granted);
+    notifyListeners();
+  }
+
+  Future<void> updateCrashConsent(bool granted) async {
+    await _setCrashConsent(granted);
+    notifyListeners();
+  }
+
+  Future<void> _setAnalyticsConsent(bool granted) async {
+    await ConsentService.setAnalyticsConsent(granted);
+    _analyticsConsent = granted;
+    _hasAnalyticsDecision = true;
+
+    if (enableFirebase) {
+      await _applyAnalyticsState(granted);
+    } else if (!granted) {
+      AnalyticsService.disable();
     }
+  }
+
+  Future<void> _setCrashConsent(bool granted) async {
+    await ConsentService.setCrashConsent(granted);
+    _crashConsent = granted;
+    _hasCrashDecision = true;
+
+    if (enableFirebase) {
+      await _applyCrashState(granted);
+    }
+  }
+
+  Future<void> _applyAnalyticsState(bool granted) async {
     final analytics = _analytics;
     if (analytics != null) {
       await analytics.setAnalyticsCollectionEnabled(granted);
-    }
-
-    if (granted) {
-      if (!AnalyticsService.enabled && analytics != null) {
-        await AnalyticsService.configure(analytics);
+      if (granted) {
+        if (!AnalyticsService.enabled) {
+          await AnalyticsService.configure(analytics);
+        }
+        await AnalyticsService.logAppOpen();
+      } else {
+        AnalyticsService.disable();
       }
-      await AnalyticsService.logAppOpen();
+    }
+  }
+
+  Future<void> _applyCrashState(bool granted) async {
+    final crashlytics = _crashlytics;
+    if (crashlytics != null) {
+      await crashlytics.setCrashlyticsCollectionEnabled(granted);
     }
   }
 }

--- a/lib/state/theme_controller.dart
+++ b/lib/state/theme_controller.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeController extends ChangeNotifier {
+  ThemeController({SharedPreferences? preferences})
+    : _providedPrefs = preferences;
+
+  static const _prefsKey = 'theme_mode';
+
+  final SharedPreferences? _providedPrefs;
+  SharedPreferences? _prefs;
+
+  ThemeMode _themeMode = ThemeMode.system;
+  bool _hasLoaded = false;
+
+  ThemeMode get themeMode => _themeMode;
+  bool get hasLoaded => _hasLoaded;
+
+  Future<void> load() async {
+    final prefs = _providedPrefs ?? await SharedPreferences.getInstance();
+    _prefs = prefs;
+    _themeMode = _stringToThemeMode(prefs.getString(_prefsKey));
+    _hasLoaded = true;
+    notifyListeners();
+  }
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_themeMode == mode && _hasLoaded) return;
+    _themeMode = mode;
+    _hasLoaded = true;
+    notifyListeners();
+
+    final prefs =
+        _prefs ?? _providedPrefs ?? await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, mode.name);
+    _prefs = prefs;
+  }
+
+  ThemeMode _stringToThemeMode(String? value) {
+    switch (value) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      case 'system':
+      default:
+        return ThemeMode.system;
+    }
+  }
+}

--- a/lib/state/theme_provider.dart
+++ b/lib/state/theme_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'theme_controller.dart';
+
+final themeControllerProvider = ChangeNotifierProvider<ThemeController>((ref) {
+  throw UnimplementedError(
+    'Override themeControllerProvider before reading it.',
+  );
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -206,6 +206,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_html:
+    dependency: "direct main"
+    description:
+      name: flutter_html
+      sha256: "38a2fd702ffdf3243fb7441ab58aa1bc7e6922d95a50db76534de8260638558d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -264,6 +272,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.6"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   image:
     dependency: transitive
     description:
@@ -312,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  list_counter:
+    dependency: transitive
+    description:
+      name: list_counter
+      sha256: c447ae3dfcd1c55f0152867090e67e219d42fe6d4f2807db4bbe8b8d69912237
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   logging:
     dependency: transitive
     description:
@@ -352,6 +384,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: f69da0d3189a4b4ceaeb1a3defb0f329b3b352517f52bed4290f83d4f06bc08d
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -581,6 +629,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.0"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,9 @@ dependencies:
   firebase_crashlytics: ^5.0.2
   shared_preferences: ^2.3.2
   flutter_native_splash: ^2.4.6
+  package_info_plus: ^9.0.0
+  http: ^1.2.2
+  flutter_html: ^3.0.0-beta.2
 
 dev_dependencies:
   flutter_test:

--- a/test/consent_prompt_overlay_test.dart
+++ b/test/consent_prompt_overlay_test.dart
@@ -4,12 +4,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:habit_tracker/main.dart';
 import 'package:habit_tracker/services/consent_service.dart';
+import 'package:habit_tracker/state/app_info_provider.dart';
+import 'package:habit_tracker/state/notification_settings_controller.dart';
+import 'package:habit_tracker/state/notification_settings_provider.dart';
 import 'package:habit_tracker/state/telemetry_controller.dart';
 import 'package:habit_tracker/state/telemetry_provider.dart';
+import 'package:habit_tracker/state/theme_controller.dart';
+import 'package:habit_tracker/state/theme_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 void main() {
   late TelemetryController controller;
+  late ThemeController themeController;
+  late NotificationSettingsController notificationController;
+  late PackageInfo packageInfo;
   late GoRouter router;
   late GlobalKey<NavigatorState> navigatorKey;
 
@@ -19,6 +28,21 @@ void main() {
 
     controller = TelemetryController(enableFirebase: false);
     await controller.initialize();
+
+    themeController = ThemeController();
+    await themeController.load();
+
+    notificationController = NotificationSettingsController();
+    await notificationController.load();
+
+    packageInfo = PackageInfo(
+      appName: 'Habit Tracker',
+      packageName: 'com.example.habit',
+      version: '1.2.3',
+      buildNumber: '42',
+      buildSignature: 'sig',
+      installerStore: null,
+    );
 
     navigatorKey = GlobalKey<NavigatorState>();
     router = GoRouter(
@@ -40,6 +64,11 @@ void main() {
     return ProviderScope(
       overrides: [
         telemetryControllerProvider.overrideWith((ref) => controller),
+        themeControllerProvider.overrideWith((ref) => themeController),
+        notificationSettingsProvider.overrideWith(
+          (ref) => notificationController,
+        ),
+        appInfoProvider.overrideWith((ref) async => packageInfo),
       ],
       child: HabitTrackerApp(router: router, rootNavigatorKey: navigatorKey),
     );

--- a/test/consent_service_test.dart
+++ b/test/consent_service_test.dart
@@ -12,20 +12,31 @@ void main() {
     await ConsentService.load();
 
     expect(ConsentService.hasLoaded, isTrue);
+    expect(ConsentService.hasAnalyticsDecision, isFalse);
+    expect(ConsentService.hasCrashDecision, isFalse);
     expect(ConsentService.hasRecordedDecision, isFalse);
+    expect(ConsentService.analyticsConsentGranted, isFalse);
+    expect(ConsentService.crashConsentGranted, isFalse);
     expect(ConsentService.consentGranted, isFalse);
   });
 
   test('setConsent persists and marks decision', () async {
     await ConsentService.load();
-    await ConsentService.setConsent(true);
+    await ConsentService.setAnalyticsConsent(true);
+    await ConsentService.setCrashConsent(false);
 
-    expect(ConsentService.consentGranted, isTrue);
+    expect(ConsentService.analyticsConsentGranted, isTrue);
+    expect(ConsentService.crashConsentGranted, isFalse);
+    expect(ConsentService.hasAnalyticsDecision, isTrue);
+    expect(ConsentService.hasCrashDecision, isTrue);
     expect(ConsentService.hasRecordedDecision, isTrue);
+    expect(ConsentService.consentGranted, isFalse);
 
     // Reload from storage to verify persistence
     await ConsentService.load();
-    expect(ConsentService.consentGranted, isTrue);
-    expect(ConsentService.hasRecordedDecision, isTrue);
+    expect(ConsentService.analyticsConsentGranted, isTrue);
+    expect(ConsentService.crashConsentGranted, isFalse);
+    expect(ConsentService.hasAnalyticsDecision, isTrue);
+    expect(ConsentService.hasCrashDecision, isTrue);
   });
 }

--- a/test/navigation_test.dart
+++ b/test/navigation_test.dart
@@ -5,11 +5,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:habit_tracker/app_router.dart';
 import 'package:habit_tracker/services/analytics_service.dart';
+import 'package:habit_tracker/state/app_info_provider.dart';
+import 'package:habit_tracker/state/notification_settings_controller.dart';
+import 'package:habit_tracker/state/notification_settings_provider.dart';
 import 'package:habit_tracker/state/telemetry_controller.dart';
 import 'package:habit_tracker/state/telemetry_provider.dart';
+import 'package:habit_tracker/state/theme_controller.dart';
+import 'package:habit_tracker/state/theme_provider.dart';
 import 'package:habit_tracker/theme/app_theme.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class _MockAnalytics extends Mock implements FirebaseAnalytics {}
 
@@ -19,9 +25,17 @@ void main() {
   late TelemetryController controller;
   late _MockAnalytics analytics;
   late _MockCrashlytics crashlytics;
+  late ThemeController themeController;
+  late NotificationSettingsController notificationController;
+  late PackageInfo packageInfo;
 
   setUp(() async {
-    SharedPreferences.setMockInitialValues({'analytics_consent': true});
+    SharedPreferences.setMockInitialValues({
+      'analytics_consent': true,
+      'crash_consent': true,
+      'notifications_enabled': true,
+      'notifications_time': '08:00',
+    });
     AnalyticsService.reset();
 
     analytics = _MockAnalytics();
@@ -53,6 +67,21 @@ void main() {
       crashlytics: crashlytics,
     );
     await controller.initialize();
+
+    themeController = ThemeController();
+    await themeController.load();
+
+    notificationController = NotificationSettingsController();
+    await notificationController.load();
+
+    packageInfo = PackageInfo(
+      appName: 'Habit Tracker',
+      packageName: 'com.example.habit',
+      version: '1.2.3',
+      buildNumber: '42',
+      buildSignature: 'sig',
+      installerStore: null,
+    );
   });
 
   testWidgets('navigates from Home to Settings', (WidgetTester tester) async {
@@ -66,6 +95,11 @@ void main() {
       ProviderScope(
         overrides: [
           telemetryControllerProvider.overrideWith((ref) => controller),
+          themeControllerProvider.overrideWith((ref) => themeController),
+          notificationSettingsProvider.overrideWith(
+            (ref) => notificationController,
+          ),
+          appInfoProvider.overrideWith((ref) async => packageInfo),
         ],
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,
@@ -109,6 +143,8 @@ void main() {
       ProviderScope(
         overrides: [
           telemetryControllerProvider.overrideWith((ref) => controller),
+          themeControllerProvider.overrideWith((ref) => themeController),
+          appInfoProvider.overrideWith((ref) async => packageInfo),
         ],
         child: MaterialApp.router(
           debugShowCheckedModeBanner: false,

--- a/test/notification_settings_controller_test.dart
+++ b/test/notification_settings_controller_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/state/notification_settings_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('load provides sensible defaults', () async {
+    final controller = NotificationSettingsController();
+    await controller.load();
+
+    expect(controller.hasLoaded, isTrue);
+    expect(controller.enabled, isFalse);
+    expect(controller.reminderTime, const TimeOfDay(hour: 8, minute: 0));
+  });
+
+  test('setEnabled persists flag', () async {
+    final controller = NotificationSettingsController();
+    await controller.load();
+
+    await controller.setEnabled(true);
+    expect(controller.enabled, isTrue);
+
+    final rehydrated = NotificationSettingsController();
+    await rehydrated.load();
+    expect(rehydrated.enabled, isTrue);
+  });
+
+  test('setReminderTime persists selection', () async {
+    final controller = NotificationSettingsController();
+    await controller.load();
+
+    const time = TimeOfDay(hour: 18, minute: 30);
+    await controller.setReminderTime(time);
+    expect(controller.reminderTime, time);
+
+    final rehydrated = NotificationSettingsController();
+    await rehydrated.load();
+    expect(rehydrated.reminderTime, time);
+  });
+}

--- a/test/privacy_policy_screen_test.dart
+++ b/test/privacy_policy_screen_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/screens/privacy_policy_screen.dart';
+import 'package:habit_tracker/state/remote_content_provider.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  testWidgets('renders privacy policy content', (tester) async {
+    final client = MockClient((request) async {
+      expect(request.url.path, contains('privacy-policy'));
+      return http.Response('Privacy policy content', 200);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [httpClientProvider.overrideWithValue(client)],
+        child: const MaterialApp(home: PrivacyPolicyScreen()),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    final htmlFinder = find.byType(Html);
+    expect(htmlFinder, findsOneWidget);
+    final htmlWidget = tester.widget<Html>(htmlFinder);
+    expect(htmlWidget.data, contains('Privacy policy content'));
+  });
+
+  testWidgets('shows error state when fetch fails', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response('oops', 500);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [httpClientProvider.overrideWithValue(client)],
+        child: const MaterialApp(home: PrivacyPolicyScreen()),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.textContaining('Failed to load privacy policy'),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/release_notes_screen_test.dart
+++ b/test/release_notes_screen_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/screens/release_notes_screen.dart';
+import 'package:habit_tracker/state/app_info_provider.dart';
+import 'package:habit_tracker/state/remote_content_provider.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  testWidgets('renders remote release notes content', (tester) async {
+    final packageInfo = PackageInfo(
+      appName: 'Habit Tracker',
+      packageName: 'com.example.habit',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: 'sig',
+      installerStore: null,
+    );
+
+    final client = MockClient((request) async {
+      expect(request.url.path, contains('release-notes/1.0.0.1'));
+      return http.Response('Release notes content', 200);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appInfoProvider.overrideWith((ref) async => packageInfo),
+          httpClientProvider.overrideWithValue(client),
+        ],
+        child: const MaterialApp(home: ReleaseNotesScreen()),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    final htmlFinder = find.byType(Html);
+    expect(htmlFinder, findsOneWidget);
+    final htmlWidget = tester.widget<Html>(htmlFinder);
+    expect(htmlWidget.data, contains('Release notes content'));
+  });
+
+  testWidgets('shows error when release notes fetch fails', (tester) async {
+    final packageInfo = PackageInfo(
+      appName: 'Habit Tracker',
+      packageName: 'com.example.habit',
+      version: '1.0.0',
+      buildNumber: '1',
+      buildSignature: 'sig',
+      installerStore: null,
+    );
+
+    final client = MockClient((request) async {
+      return http.Response('not found', 404);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          appInfoProvider.overrideWith((ref) async => packageInfo),
+          httpClientProvider.overrideWithValue(client),
+        ],
+        child: const MaterialApp(home: ReleaseNotesScreen()),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.textContaining('Failed to load release notes'), findsOneWidget);
+  });
+}

--- a/test/settings_screen_test.dart
+++ b/test/settings_screen_test.dart
@@ -4,12 +4,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:habit_tracker/screens/settings_screen.dart';
 import 'package:habit_tracker/services/analytics_service.dart';
 import 'package:habit_tracker/services/consent_service.dart';
+import 'package:habit_tracker/state/app_info_provider.dart';
+import 'package:habit_tracker/state/notification_settings_controller.dart';
+import 'package:habit_tracker/state/notification_settings_provider.dart';
 import 'package:habit_tracker/state/telemetry_controller.dart';
 import 'package:habit_tracker/state/telemetry_provider.dart';
+import 'package:habit_tracker/state/theme_controller.dart';
+import 'package:habit_tracker/state/theme_provider.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 
 class _MockAnalytics extends Mock implements FirebaseAnalytics {}
 
@@ -19,6 +25,9 @@ void main() {
   late TelemetryController controller;
   late _MockAnalytics analytics;
   late _MockCrashlytics crashlytics;
+  late ThemeController themeController;
+  late NotificationSettingsController notificationController;
+  late PackageInfo packageInfo;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -41,28 +50,129 @@ void main() {
       crashlytics: crashlytics,
     );
     await controller.initialize();
+
+    themeController = ThemeController();
+    await themeController.load();
+
+    notificationController = NotificationSettingsController();
+    await notificationController.load();
+
+    packageInfo = PackageInfo(
+      appName: 'Habit Tracker',
+      packageName: 'com.example.habit',
+      version: '1.2.3',
+      buildNumber: '42',
+      buildSignature: 'sig',
+      installerStore: null,
+    );
   });
 
-  testWidgets('toggle updates consent state', (WidgetTester tester) async {
+  testWidgets('analytics and crash toggles update consent state', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           telemetryControllerProvider.overrideWith((ref) => controller),
+          themeControllerProvider.overrideWith((ref) => themeController),
+          notificationSettingsProvider.overrideWith(
+            (ref) => notificationController,
+          ),
+          appInfoProvider.overrideWith((ref) async => packageInfo),
         ],
         child: const MaterialApp(home: SettingsScreen()),
       ),
     );
 
-    await tester.pump();
-
-    final toggle = find.byType(SwitchListTile);
-    expect(toggle, findsOneWidget);
-
-    expect(controller.isConsentGranted, isFalse);
-
-    await tester.tap(toggle);
     await tester.pumpAndSettle();
 
+    final analyticsSwitch = find.byKey(const Key('switch_analytics_consent'));
+    final crashSwitch = find.byKey(const Key('switch_crash_consent'));
+    expect(analyticsSwitch, findsOneWidget);
+    expect(crashSwitch, findsOneWidget);
+
+    expect(controller.isAnalyticsEnabled, isFalse);
+    expect(controller.isCrashEnabled, isFalse);
+
+    await tester.tap(analyticsSwitch);
+    await tester.pumpAndSettle();
+
+    expect(controller.isAnalyticsEnabled, isTrue);
+    expect(controller.isCrashEnabled, isFalse);
+
+    await tester.tap(crashSwitch);
+    await tester.pumpAndSettle();
+
+    expect(controller.isCrashEnabled, isTrue);
     expect(controller.isConsentGranted, isTrue);
+  });
+
+  testWidgets('changing theme updates controller', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          telemetryControllerProvider.overrideWith((ref) => controller),
+          themeControllerProvider.overrideWith((ref) => themeController),
+          notificationSettingsProvider.overrideWith(
+            (ref) => notificationController,
+          ),
+          appInfoProvider.overrideWith((ref) async => packageInfo),
+        ],
+        child: const MaterialApp(home: SettingsScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+    expect(themeController.themeMode, ThemeMode.system);
+
+    final dropdownFinder = find.byType(DropdownButtonFormField<ThemeMode>);
+    expect(dropdownFinder, findsOneWidget);
+
+    final dropdownWidget = tester.widget<DropdownButtonFormField<ThemeMode>>(
+      dropdownFinder,
+    );
+    dropdownWidget.onChanged?.call(ThemeMode.dark);
+    await tester.pumpAndSettle();
+
+    expect(themeController.themeMode, ThemeMode.dark);
+  });
+
+  testWidgets('notification settings toggle and time row respond', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          telemetryControllerProvider.overrideWith((ref) => controller),
+          themeControllerProvider.overrideWith((ref) => themeController),
+          notificationSettingsProvider.overrideWith(
+            (ref) => notificationController,
+          ),
+          appInfoProvider.overrideWith((ref) async => packageInfo),
+        ],
+        child: const MaterialApp(home: SettingsScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final notificationsSwitch = find.byKey(
+      const Key('switch_notifications_enabled'),
+    );
+    final timeTile = find.byKey(const Key('tile_notification_time'));
+
+    expect(notificationsSwitch, findsOneWidget);
+    expect(timeTile, findsOneWidget);
+    expect(notificationController.enabled, isFalse);
+
+    await tester.tap(notificationsSwitch);
+    await tester.pumpAndSettle();
+
+    expect(notificationController.enabled, isTrue);
+
+    // Tapping the time tile should open a time picker; we cannot interact with it
+    // in this unit test, but we ensure the tile is enabled once notifications are.
+    final listTile = tester.widget<ListTile>(timeTile);
+    expect(listTile.enabled, isTrue);
   });
 }

--- a/test/telemetry_controller_test.dart
+++ b/test/telemetry_controller_test.dart
@@ -61,7 +61,8 @@ void main() {
 
     expect(controller.isLoaded, isTrue);
     expect(controller.hasRecordedDecision, isFalse);
-    expect(controller.isConsentGranted, isFalse);
+    expect(controller.isAnalyticsEnabled, isFalse);
+    expect(controller.isCrashEnabled, isFalse);
     expect(AnalyticsService.enabled, isFalse);
 
     verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
@@ -69,7 +70,10 @@ void main() {
   });
 
   test('initialize enables telemetry when consent stored', () async {
-    SharedPreferences.setMockInitialValues({'analytics_consent': true});
+    SharedPreferences.setMockInitialValues({
+      'analytics_consent': true,
+      'crash_consent': true,
+    });
 
     final analytics = buildAnalyticsMock();
     final crashlytics = buildCrashlyticsMock();
@@ -104,6 +108,8 @@ void main() {
 
     await controller.updateConsent(true);
     expect(controller.isConsentGranted, isTrue);
+    expect(controller.isAnalyticsEnabled, isTrue);
+    expect(controller.isCrashEnabled, isTrue);
     verify(() => analytics.setAnalyticsCollectionEnabled(true)).called(2);
     verify(() => crashlytics.setCrashlyticsCollectionEnabled(true)).called(1);
 
@@ -112,7 +118,57 @@ void main() {
 
     await controller.updateConsent(false);
     expect(controller.isConsentGranted, isFalse);
+    expect(controller.isAnalyticsEnabled, isFalse);
+    expect(controller.isCrashEnabled, isFalse);
     verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(false)).called(1);
+  });
+
+  test('updateAnalyticsConsent toggles analytics only', () async {
+    final analytics = buildAnalyticsMock();
+    final crashlytics = buildCrashlyticsMock();
+
+    final controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+    await controller.initialize();
+
+    await controller.updateAnalyticsConsent(true);
+    expect(controller.isAnalyticsEnabled, isTrue);
+    expect(controller.isCrashEnabled, isFalse);
+    verify(() => analytics.setAnalyticsCollectionEnabled(true)).called(2);
+    verifyNever(() => crashlytics.setCrashlyticsCollectionEnabled(true));
+
+    clearInteractions(analytics);
+
+    await controller.updateAnalyticsConsent(false);
+    expect(controller.isAnalyticsEnabled, isFalse);
+    verify(() => analytics.setAnalyticsCollectionEnabled(false)).called(1);
+  });
+
+  test('updateCrashConsent toggles crash collection only', () async {
+    final analytics = buildAnalyticsMock();
+    final crashlytics = buildCrashlyticsMock();
+
+    final controller = TelemetryController(
+      enableFirebase: true,
+      analytics: analytics,
+      crashlytics: crashlytics,
+    );
+    await controller.initialize();
+
+    await controller.updateCrashConsent(true);
+    expect(controller.isCrashEnabled, isTrue);
+    expect(controller.isAnalyticsEnabled, isFalse);
+    verify(() => crashlytics.setCrashlyticsCollectionEnabled(true)).called(1);
+    verifyNever(() => analytics.setAnalyticsCollectionEnabled(true));
+
+    clearInteractions(crashlytics);
+
+    await controller.updateCrashConsent(false);
+    expect(controller.isCrashEnabled, isFalse);
     verify(() => crashlytics.setCrashlyticsCollectionEnabled(false)).called(1);
   });
 }

--- a/test/theme_controller_test.dart
+++ b/test/theme_controller_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_tracker/state/theme_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('load defaults to system when no preference stored', () async {
+    final controller = ThemeController();
+    expect(controller.themeMode, ThemeMode.system);
+    expect(controller.hasLoaded, isFalse);
+
+    await controller.load();
+
+    expect(controller.hasLoaded, isTrue);
+    expect(controller.themeMode, ThemeMode.system);
+  });
+
+  test('setThemeMode persists preference and notifies listeners', () async {
+    final controller = ThemeController();
+    await controller.load();
+
+    var notified = false;
+    controller.addListener(() {
+      notified = true;
+    });
+
+    await controller.setThemeMode(ThemeMode.dark);
+
+    expect(controller.themeMode, ThemeMode.dark);
+    expect(notified, isTrue);
+
+    final rehydrated = ThemeController();
+    await rehydrated.load();
+
+    expect(rehydrated.themeMode, ThemeMode.dark);
+  });
+
+  test('setThemeMode ignores duplicate updates', () async {
+    final controller = ThemeController();
+    await controller.load();
+    await controller.setThemeMode(ThemeMode.light);
+
+    var notifyCount = 0;
+    controller.addListener(() {
+      notifyCount += 1;
+    });
+
+    await controller.setThemeMode(ThemeMode.light);
+
+    expect(notifyCount, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add notification settings controller/providers with UI toggles and reminder time
- fetch release notes and privacy policy from configurable URL with HTML rendering
- split analytics/crash consents, update tests, and add release notes HTML placeholder

## Testing
- flutter analyze
- flutter test --coverage