### PR TITLE
feat: set up hive database infrastructure

### DIFF
--- a/lib/core/database/habit_database.dart
+++ b/lib/core/database/habit_database.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../features/habits/data/models/habit_entry_record.dart';
+import '../../features/habits/data/models/habit_record.dart';
+
+class HabitDatabase {
+  HabitDatabase({HiveInterface? hive, Future<void> Function()? initializer})
+    : _hive = hive ?? Hive,
+      _initializer = initializer ?? Hive.initFlutter;
+
+  static const String habitsBoxName = 'habits';
+  static const String habitEntriesBoxName = 'habit_entries';
+
+  final HiveInterface _hive;
+  final Future<void> Function() _initializer;
+
+  bool _initialized = false;
+  bool _initializerRan = false;
+
+  bool get isInitialized => _initialized;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+
+    if (!_initializerRan) {
+      await _initializer();
+      _initializerRan = true;
+    }
+
+    _registerAdapters();
+
+    await Future.wait([
+      _hive.openBox<HabitRecord>(habitsBoxName),
+      _hive.openBox<HabitEntryRecord>(habitEntriesBoxName),
+    ]);
+
+    _initialized = true;
+  }
+
+  Future<void> close() async {
+    if (!_initialized) return;
+
+    await _hive.close();
+    _initialized = false;
+  }
+
+  Box<HabitRecord> get habitsBox {
+    _ensureInitialized();
+    return _hive.box<HabitRecord>(habitsBoxName);
+  }
+
+  Box<HabitEntryRecord> get habitEntriesBox {
+    _ensureInitialized();
+    return _hive.box<HabitEntryRecord>(habitEntriesBoxName);
+  }
+
+  void _registerAdapters() {
+    final habitAdapter = HabitRecordAdapter();
+    if (!_hive.isAdapterRegistered(habitAdapter.typeId)) {
+      _hive.registerAdapter(habitAdapter);
+    }
+
+    final entryAdapter = HabitEntryRecordAdapter();
+    if (!_hive.isAdapterRegistered(entryAdapter.typeId)) {
+      _hive.registerAdapter(entryAdapter);
+    }
+  }
+
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError('HabitDatabase.initialize() must be called before use.');
+    }
+  }
+}
+
+final habitDatabaseProvider = Provider<HabitDatabase>((ref) {
+  throw UnimplementedError('habitDatabaseProvider must be overridden');
+});

--- a/lib/core/database/habit_database.dart
+++ b/lib/core/database/habit_database.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 import '../../features/habits/data/models/habit_entry_record.dart';

--- a/lib/features/habits/data/models/habit_entry_record.dart
+++ b/lib/features/habits/data/models/habit_entry_record.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../domain/domain.dart';
+
+@immutable
+class HabitEntryRecord {
+  const HabitEntryRecord({
+    required this.habitId,
+    required this.date,
+    required this.done,
+  });
+
+  final String habitId;
+  final DateTime date;
+  final bool done;
+
+  HabitEntry toHabitEntry() {
+    return HabitEntry(habitId: habitId, date: date, done: done);
+  }
+
+  factory HabitEntryRecord.fromHabitEntry(HabitEntry entry) {
+    return HabitEntryRecord(
+      habitId: entry.habitId,
+      date: entry.date,
+      done: entry.done,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is HabitEntryRecord &&
+        other.habitId == habitId &&
+        other.date == date &&
+        other.done == done;
+  }
+
+  @override
+  int get hashCode => Object.hash(habitId, date, done);
+
+  @override
+  String toString() =>
+      'HabitEntryRecord(habitId: $habitId, date: $date, done: $done)';
+}
+
+class HabitEntryRecordAdapter extends TypeAdapter<HabitEntryRecord> {
+  @override
+  final int typeId = 2;
+
+  @override
+  HabitEntryRecord read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+
+    return HabitEntryRecord(
+      habitId: fields[0] as String,
+      date: fields[1] as DateTime,
+      done: fields[2] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, HabitEntryRecord obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.habitId)
+      ..writeByte(1)
+      ..write(obj.date)
+      ..writeByte(2)
+      ..write(obj.done);
+  }
+}

--- a/lib/features/habits/data/models/habit_record.dart
+++ b/lib/features/habits/data/models/habit_record.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+import '../../domain/domain.dart';
+
+@immutable
+class HabitRecord {
+  HabitRecord({
+    required this.id,
+    required this.name,
+    required this.emoji,
+    required this.color,
+    required List<int> days,
+    required this.reminderId,
+    required this.reminderTime,
+    required this.bestStreak,
+    required this.currentStreak,
+    this.lastChecked,
+  }) : days = List<int>.unmodifiable(List<int>.from(days));
+
+  final String id;
+  final String name;
+  final String emoji;
+  final int color;
+  final List<int> days;
+  final String reminderId;
+  final String reminderTime;
+  final int bestStreak;
+  final int currentStreak;
+  final DateTime? lastChecked;
+
+  Habit toHabit() {
+    return Habit(
+      id: id,
+      name: name,
+      emoji: emoji,
+      color: color,
+      days: List<int>.from(days),
+      reminderId: reminderId,
+      reminderTime: reminderTime,
+      bestStreak: bestStreak,
+      currentStreak: currentStreak,
+      lastChecked: lastChecked,
+    );
+  }
+
+  factory HabitRecord.fromHabit(Habit habit) {
+    return HabitRecord(
+      id: habit.id,
+      name: habit.name,
+      emoji: habit.emoji,
+      color: habit.color,
+      days: habit.days,
+      reminderId: habit.reminderId,
+      reminderTime: habit.reminderTime,
+      bestStreak: habit.bestStreak,
+      currentStreak: habit.currentStreak,
+      lastChecked: habit.lastChecked,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is HabitRecord &&
+        other.id == id &&
+        other.name == name &&
+        other.emoji == emoji &&
+        other.color == color &&
+        listEquals(other.days, days) &&
+        other.reminderId == reminderId &&
+        other.reminderTime == reminderTime &&
+        other.bestStreak == bestStreak &&
+        other.currentStreak == currentStreak &&
+        other.lastChecked == lastChecked;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    name,
+    emoji,
+    color,
+    Object.hashAll(days),
+    reminderId,
+    reminderTime,
+    bestStreak,
+    currentStreak,
+    lastChecked,
+  );
+
+  @override
+  String toString() {
+    return 'HabitRecord(id: $id, name: $name, streak: $currentStreak/$bestStreak)';
+  }
+}
+
+class HabitRecordAdapter extends TypeAdapter<HabitRecord> {
+  @override
+  final int typeId = 1;
+
+  @override
+  HabitRecord read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (var i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+
+    return HabitRecord(
+      id: fields[0] as String,
+      name: fields[1] as String,
+      emoji: fields[2] as String,
+      color: fields[3] as int,
+      days: (fields[4] as List).cast<int>(),
+      reminderId: fields[5] as String,
+      reminderTime: fields[6] as String,
+      bestStreak: fields[7] as int,
+      currentStreak: fields[8] as int,
+      lastChecked: fields[9] as DateTime?,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, HabitRecord obj) {
+    writer
+      ..writeByte(10)
+      ..writeByte(0)
+      ..write(obj.id)
+      ..writeByte(1)
+      ..write(obj.name)
+      ..writeByte(2)
+      ..write(obj.emoji)
+      ..writeByte(3)
+      ..write(obj.color)
+      ..writeByte(4)
+      ..write(obj.days)
+      ..writeByte(5)
+      ..write(obj.reminderId)
+      ..writeByte(6)
+      ..write(obj.reminderTime)
+      ..writeByte(7)
+      ..write(obj.bestStreak)
+      ..writeByte(8)
+      ..write(obj.currentStreak)
+      ..writeByte(9)
+      ..write(obj.lastChecked);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'core/localization/l10n_extensions.dart';
 import 'core/router/app_router.dart';
 import 'core/telemetry/controllers/telemetry_controller.dart';
 import 'core/telemetry/providers/telemetry_provider.dart';
+import 'core/database/habit_database.dart';
 import 'features/settings/application/controllers/theme_controller.dart';
 import 'features/settings/application/controllers/language_controller.dart';
 import 'features/settings/application/providers/theme_provider.dart';
@@ -46,6 +47,8 @@ Future<void> main() async {
 
   final enableFirebase = kFirebaseEnabled || kReleaseMode;
   final rootNavigatorKey = GlobalKey<NavigatorState>();
+  final database = HabitDatabase();
+  await database.initialize();
   if (enableFirebase) {
     try {
       await Firebase.initializeApp(options: firebaseOptions);
@@ -117,6 +120,7 @@ Future<void> main() async {
         notificationSettingsProvider.overrideWith(
           (ref) => notificationSettingsController,
         ),
+        habitDatabaseProvider.overrideWithValue(database),
       ],
       child: HabitTrackerApp(
         router: router,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,6 +269,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.2.4"
+  hive:
+    dependency: "direct main"
+    description:
+      name: hive
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
+  hive_flutter:
+    dependency: "direct main"
+    description:
+      name: hive_flutter
+      sha256: dca1da446b1d808a51689fb5d0c6c9510c0a2ba01e22805d492c73b68e33eecc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   html:
     dependency: transitive
     description:
@@ -421,6 +437,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.18"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   flutter_native_splash: ^2.4.6
   package_info_plus: ^9.0.0
   http: ^1.2.2
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
   flutter_localizations:
     sdk: flutter
   flutter_html: ^3.0.0-beta.2

--- a/test/core/database/habit_database_test.dart
+++ b/test/core/database/habit_database_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habit_tracker/core/database/habit_database.dart';
+import 'package:habit_tracker/features/habits/data/models/habit_entry_record.dart';
+import 'package:habit_tracker/features/habits/data/models/habit_record.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit_entry.dart';
+
+void main() {
+  late Directory tempDir;
+  late HabitDatabase database;
+
+  Habit buildHabit() {
+    return Habit(
+      id: 'habit-123',
+      name: 'Read',
+      emoji: '📚',
+      color: 0xFFAA00AA,
+      days: [0, 1, 2],
+      reminderId: 'rem-123',
+      reminderTime: '20:30',
+      bestStreak: 15,
+      currentStreak: 4,
+      lastChecked: DateTime(2024, 9, 23, 22, 5),
+    );
+  }
+
+  HabitEntry buildEntry() {
+    return HabitEntry(
+      habitId: 'habit-123',
+      date: DateTime(2024, 9, 24),
+      done: true,
+    );
+  }
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('habit_database_test');
+    Hive.init(tempDir.path);
+    database = HabitDatabase(hive: Hive, initializer: () async {});
+  });
+
+  tearDown(() async {
+    await database.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('initialize opens Hive boxes and registers adapters', () async {
+    await database.initialize();
+
+    expect(database.isInitialized, isTrue);
+    expect(database.habitsBox.isOpen, isTrue);
+    expect(database.habitEntriesBox.isOpen, isTrue);
+
+    final habit = buildHabit();
+    final record = HabitRecord.fromHabit(habit);
+    await database.habitsBox.put(record.id, record);
+
+    final restoredHabit = database.habitsBox.get(record.id);
+    expect(restoredHabit?.toHabit(), habit);
+
+    final entry = buildEntry();
+    final entryRecord = HabitEntryRecord.fromHabitEntry(entry);
+    await database.habitEntriesBox.put(entry.habitId, entryRecord);
+
+    final restoredEntry = database.habitEntriesBox.get(entry.habitId);
+    expect(restoredEntry?.toHabitEntry(), entry);
+  });
+
+  test('close releases resources and prevents access', () async {
+    await database.initialize();
+    await database.close();
+
+    expect(database.isInitialized, isFalse);
+    expect(() => database.habitsBox, throwsStateError);
+    expect(() => database.habitEntriesBox, throwsStateError);
+  });
+
+  test('initialize is idempotent', () async {
+    await database.initialize();
+    await database.initialize();
+
+    expect(database.isInitialized, isTrue);
+  });
+}

--- a/test/features/habits/data/models/habit_entry_record_test.dart
+++ b/test/features/habits/data/models/habit_entry_record_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habit_tracker/features/habits/data/models/habit_entry_record.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit_entry.dart';
+
+void main() {
+  HabitEntry buildEntry() {
+    return HabitEntry(
+      habitId: 'habit-1',
+      date: DateTime(2024, 10, 2),
+      done: true,
+    );
+  }
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('habit_entry_record_test');
+    Hive.init(tempDir.path);
+
+    final adapter = HabitEntryRecordAdapter();
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('fromHabitEntry and toHabitEntry round trip', () {
+    final entry = buildEntry();
+    final record = HabitEntryRecord.fromHabitEntry(entry);
+
+    expect(record.toHabitEntry(), entry);
+  });
+
+  test('adapter persists entry in Hive box', () async {
+    final box = await Hive.openBox<HabitEntryRecord>('habit_entries_test');
+
+    final entry = buildEntry();
+    final record = HabitEntryRecord.fromHabitEntry(entry);
+
+    await box.put('${entry.habitId}-${entry.date.toIso8601String()}', record);
+    final restored = box.get(
+      '${entry.habitId}-${entry.date.toIso8601String()}',
+    );
+
+    expect(restored, record);
+    expect(restored?.toHabitEntry(), entry);
+
+    await box.close();
+  });
+}

--- a/test/features/habits/data/models/habit_record_test.dart
+++ b/test/features/habits/data/models/habit_record_test.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habit_tracker/features/habits/data/models/habit_record.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit.dart';
+
+void main() {
+  Habit buildHabit() {
+    return Habit(
+      id: 'habit-1',
+      name: 'Drink Water',
+      emoji: '💧',
+      color: 0xFF00AAFF,
+      days: [1, 3, 5],
+      reminderId: 'reminder-1',
+      reminderTime: '09:00',
+      bestStreak: 7,
+      currentStreak: 2,
+      lastChecked: DateTime(2024, 10, 1),
+    );
+  }
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('habit_record_test');
+    Hive.init(tempDir.path);
+
+    final adapter = HabitRecordAdapter();
+    if (!Hive.isAdapterRegistered(adapter.typeId)) {
+      Hive.registerAdapter(adapter);
+    }
+  });
+
+  tearDown(() async {
+    await Hive.close();
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('fromHabit and toHabit round trip preserves values', () {
+    final habit = buildHabit();
+    final record = HabitRecord.fromHabit(habit);
+
+    expect(record.toHabit(), habit);
+  });
+
+  test('adapter stores and restores record in Hive box', () async {
+    final box = await Hive.openBox<HabitRecord>('habits_test');
+
+    final habit = buildHabit();
+    final record = HabitRecord.fromHabit(habit);
+
+    await box.put(record.id, record);
+    final restored = box.get(record.id);
+
+    expect(restored, record);
+    expect(restored?.toHabit(), habit);
+
+    await box.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add Hive dependencies and initialize the database during app startup
- implement a Hive-backed HabitDatabase with adapters for habits and entries
- add persistence models and unit tests covering adapters and database lifecycle

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68e2c382b5f88325a8e4621eddafa10f