### PR TITLE
docs: add analytics instrumentation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Guidelines for Habit Tracker
+
+## Scope
+These instructions apply to the entire repository unless a nested `AGENTS.md` overrides them.
+
+## Tooling & Environment
+- Manage the Flutter SDK with [FVM](https://fvm.app/) and use the pinned version from `.fvmrc` (currently `3.35.4`). Prefer commands prefixed with `fvm flutter …` so the correct SDK is used.
+- Run `fvm flutter pub get` whenever you change dependencies or add new packages.
+- Before delivering changes, run the static analysis suite with `fvm flutter analyze`.
+- Execute the test suite with coverage using `fvm flutter test --coverage`. Ensure the patch coverage reported locally stays at or above the 60% minimum defined in `codecov.yml`.
+
+## Code Style & Architecture
+- Follow the lints configured in `analysis_options.yaml`; avoid disabling rules unless absolutely necessary and document any exceptions inline.
+- Keep imports organized and prefer using existing abstractions (Riverpod providers, GoRouter routes, theme extensions) over introducing duplicate patterns.
+- When introducing new state or services, back them with unit tests in `test/` and, if applicable, provider integration tests.
+
+## Localization & Assets
+- Add user-facing strings to the ARB files under `lib/l10n/` and regenerate localizations with `fvm flutter gen-l10n`.
+- Register new assets in `pubspec.yaml` under the appropriate section and include platform-specific setup if required.
+
+## Documentation & Changelog
+- Update relevant documentation (e.g., `README.md`, `docs/`) when adding features or changing workflows.
+- For behavior changes, include or update tests demonstrating the expected UX.
+
+## Analytics & Telemetry
+- Route all analytics instrumentation through `AnalyticsService` so that consent toggles remain respected across platforms.
+- When introducing a new analytics event, document the event name, triggering interaction, and expected parameters in `docs/analytics_events.md`.
+- Cover analytics flows with unit or widget tests that assert consent-gated behavior (e.g., verifying that collection is disabled when a user opts out).

--- a/docs/analytics_events.md
+++ b/docs/analytics_events.md
@@ -1,0 +1,14 @@
+# Analytics Event Catalog
+
+This document lists the analytics events currently instrumented in the Habit Tracker app. Update it whenever you add, rename, or remove an event so that product, marketing, and data teams have a reliable reference.
+
+| Event Name | Trigger | Parameters | Notes |
+|------------|---------|------------|-------|
+| `open_settings_tap` | User taps the settings icon on the home screen. | _None_ | Logged via `AnalyticsService.logEvent` when the settings button is pressed. |
+| `add_habit_tap` | User taps the add habit button on the home screen. | _None_ | Logged via `AnalyticsService.logEvent` when starting the add habit flow. |
+
+## Instrumentation checklist
+
+- Ensure events are routed through `AnalyticsService` so they honor consent state.
+- Add or update automated tests verifying analytics is enabled/disabled based on user consent when applicable.
+- Confirm new events do not include personally identifiable information and align with the privacy policy in `docs/privacy-policy.html`.


### PR DESCRIPTION
## Summary
- add repository-wide analytics instrumentation guidance to `AGENTS.md`
- document existing analytics events and provide an instrumentation checklist in `docs/analytics_events.md`

## Testing
- not run (fvm command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2d0a37aac8325bf34e9e5fa0022e6