### PR TITLE
feat: add Hive-backed habit repositories

### DIFF
--- a/lib/features/habits/data/repositories/habit_entries_repository.dart
+++ b/lib/features/habits/data/repositories/habit_entries_repository.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../core/database/habit_database.dart';
+import '../../domain/domain.dart';
+import '../models/habit_entry_record.dart';
+
+class HabitEntriesRepository {
+  HabitEntriesRepository(this._database);
+
+  final HabitDatabase _database;
+
+  Future<HabitEntry?> findEntry(String habitId, DateTime date) async {
+    final box = _database.habitEntriesBox;
+    final record = box.get(_entryKey(habitId, date));
+    return record?.toHabitEntry();
+  }
+
+  Future<List<HabitEntry>> fetchEntries({String? habitId}) async {
+    final box = _database.habitEntriesBox;
+    return _mapEntries(box, habitId: habitId);
+  }
+
+  Future<void> saveEntry(HabitEntry entry) async {
+    final box = _database.habitEntriesBox;
+    final record = HabitEntryRecord.fromHabitEntry(entry);
+    await box.put(_entryKey(entry.habitId, entry.date), record);
+  }
+
+  Future<void> deleteEntry(String habitId, DateTime date) async {
+    final box = _database.habitEntriesBox;
+    await box.delete(_entryKey(habitId, date));
+  }
+
+  Future<void> deleteEntriesForHabit(String habitId) async {
+    final box = _database.habitEntriesBox;
+    final keysToRemove = box.keys
+        .where((key) {
+          return key is String && key.startsWith(_habitPrefix(habitId));
+        })
+        .toList(growable: false);
+    await box.deleteAll(keysToRemove);
+  }
+
+  Stream<List<HabitEntry>> watchEntries({String? habitId}) {
+    final box = _database.habitEntriesBox;
+    StreamSubscription<BoxEvent>? subscription;
+    late final StreamController<List<HabitEntry>> controller;
+
+    void emitSnapshot() {
+      if (!controller.isClosed) {
+        controller.add(_mapEntries(box, habitId: habitId));
+      }
+    }
+
+    controller = StreamController<List<HabitEntry>>.broadcast(
+      onListen: () {
+        emitSnapshot();
+        subscription = box.watch().listen((_) => emitSnapshot());
+      },
+      onCancel: () async {
+        await subscription?.cancel();
+        subscription = null;
+      },
+    );
+
+    return controller.stream;
+  }
+
+  List<HabitEntry> _mapEntries(Box<HabitEntryRecord> box, {String? habitId}) {
+    final entries =
+        box.values
+            .where((record) => habitId == null || record.habitId == habitId)
+            .map((record) => record.toHabitEntry())
+            .toList(growable: false)
+          ..sort((a, b) => a.date.compareTo(b.date));
+    return List<HabitEntry>.unmodifiable(entries);
+  }
+
+  static String _entryKey(String habitId, DateTime date) {
+    return '${_habitPrefix(habitId)}${date.toIso8601String()}';
+  }
+
+  static String _habitPrefix(String habitId) => '$habitId|';
+}
+
+final habitEntriesRepositoryProvider = Provider<HabitEntriesRepository>((ref) {
+  final database = ref.watch(habitDatabaseProvider);
+  return HabitEntriesRepository(database);
+});

--- a/lib/features/habits/data/repositories/habits_repository.dart
+++ b/lib/features/habits/data/repositories/habits_repository.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../../../../core/database/habit_database.dart';
+import '../../domain/domain.dart';
+import '../models/habit_record.dart';
+
+class HabitsRepository {
+  HabitsRepository(this._database);
+
+  final HabitDatabase _database;
+
+  Future<List<Habit>> fetchHabits() async {
+    final box = _database.habitsBox;
+    return _mapHabits(box);
+  }
+
+  Future<Habit?> findById(String id) async {
+    final box = _database.habitsBox;
+    final record = box.get(id);
+    return record?.toHabit();
+  }
+
+  Future<void> saveHabit(Habit habit) async {
+    final box = _database.habitsBox;
+    final record = HabitRecord.fromHabit(habit);
+    await box.put(record.id, record);
+  }
+
+  Future<void> deleteHabit(String id) async {
+    final box = _database.habitsBox;
+    await box.delete(id);
+  }
+
+  Stream<List<Habit>> watchHabits() {
+    final box = _database.habitsBox;
+    StreamSubscription<BoxEvent>? subscription;
+    late final StreamController<List<Habit>> controller;
+
+    void emitSnapshot() {
+      if (!controller.isClosed) {
+        controller.add(_mapHabits(box));
+      }
+    }
+
+    controller = StreamController<List<Habit>>.broadcast(
+      onListen: () {
+        emitSnapshot();
+        subscription = box.watch().listen((_) => emitSnapshot());
+      },
+      onCancel: () async {
+        await subscription?.cancel();
+        subscription = null;
+      },
+    );
+
+    return controller.stream;
+  }
+
+  List<Habit> _mapHabits(Box<HabitRecord> box) {
+    return List<Habit>.unmodifiable(
+      box.values.map((record) => record.toHabit()),
+    );
+  }
+}
+
+final habitsRepositoryProvider = Provider<HabitsRepository>((ref) {
+  final database = ref.watch(habitDatabaseProvider);
+  return HabitsRepository(database);
+});

--- a/test/features/habits/data/repositories/habit_entries_repository_test.dart
+++ b/test/features/habits/data/repositories/habit_entries_repository_test.dart
@@ -1,0 +1,124 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habit_tracker/core/database/habit_database.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habit_entries_repository.dart';
+import 'package:habit_tracker/features/habits/domain/domain.dart';
+
+void main() {
+  late Directory tempDir;
+  late HabitDatabase database;
+  late HabitEntriesRepository repository;
+  late HiveInterface hive;
+
+  HabitEntry buildEntry(String habitId, DateTime date, {bool done = true}) {
+    return HabitEntry(habitId: habitId, date: date, done: done);
+  }
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('habit_entries_db_test');
+    hive = Hive;
+    database = HabitDatabase(
+      hive: hive,
+      initializer: () async {
+        hive.init(tempDir.path);
+      },
+    );
+    await database.initialize();
+    repository = HabitEntriesRepository(database);
+  });
+
+  tearDown(() async {
+    await database.close();
+    await hive.deleteFromDisk();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('saveEntry stores the entry and fetchEntries returns it', () async {
+    final entry = buildEntry('habit_a', DateTime(2024, 1, 1));
+
+    await repository.saveEntry(entry);
+
+    final entries = await repository.fetchEntries(habitId: 'habit_a');
+
+    expect(entries, <HabitEntry>[entry]);
+  });
+
+  test('fetchEntries sorts entries by date ascending', () async {
+    final entryOlder = buildEntry('habit_a', DateTime(2024, 1, 1));
+    final entryNewer = buildEntry('habit_a', DateTime(2024, 1, 2));
+
+    await repository.saveEntry(entryNewer);
+    await repository.saveEntry(entryOlder);
+
+    final entries = await repository.fetchEntries(habitId: 'habit_a');
+
+    expect(entries, <HabitEntry>[entryOlder, entryNewer]);
+  });
+
+  test('findEntry returns the entry when present', () async {
+    final entry = buildEntry('habit_a', DateTime(2024, 2, 10));
+    await repository.saveEntry(entry);
+
+    final result = await repository.findEntry(entry.habitId, entry.date);
+
+    expect(result, entry);
+  });
+
+  test('findEntry returns null when entry is missing', () async {
+    final result = await repository.findEntry('habit_a', DateTime(2024, 2, 10));
+
+    expect(result, isNull);
+  });
+
+  test('deleteEntry removes the stored entry', () async {
+    final entry = buildEntry('habit_a', DateTime(2024, 3, 1));
+    await repository.saveEntry(entry);
+
+    await repository.deleteEntry(entry.habitId, entry.date);
+
+    final entries = await repository.fetchEntries(habitId: 'habit_a');
+    expect(entries, isEmpty);
+  });
+
+  test('deleteEntriesForHabit removes only matching entries', () async {
+    final entryA1 = buildEntry('habit_a', DateTime(2024, 4, 1));
+    final entryA2 = buildEntry('habit_a', DateTime(2024, 4, 2));
+    final entryB = buildEntry('habit_b', DateTime(2024, 4, 1));
+
+    await repository.saveEntry(entryA1);
+    await repository.saveEntry(entryA2);
+    await repository.saveEntry(entryB);
+
+    await repository.deleteEntriesForHabit('habit_a');
+
+    final entriesA = await repository.fetchEntries(habitId: 'habit_a');
+    final entriesB = await repository.fetchEntries(habitId: 'habit_b');
+
+    expect(entriesA, isEmpty);
+    expect(entriesB, <HabitEntry>[entryB]);
+  });
+
+  test('watchEntries emits updates for the specified habit', () async {
+    final entryA = buildEntry('habit_watch', DateTime(2024, 5, 1));
+    final entryB = buildEntry('habit_watch', DateTime(2024, 5, 2));
+
+    final expectation = expectLater(
+      repository.watchEntries(habitId: 'habit_watch'),
+      emitsInOrder(<Object?>[
+        <HabitEntry>[],
+        <HabitEntry>[entryA],
+        <HabitEntry>[entryA, entryB],
+        <HabitEntry>[entryB],
+      ]),
+    );
+
+    await repository.saveEntry(entryA);
+    await repository.saveEntry(entryB);
+    await repository.deleteEntry(entryA.habitId, entryA.date);
+
+    await expectation;
+  });
+}

--- a/test/features/habits/data/repositories/habits_repository_test.dart
+++ b/test/features/habits/data/repositories/habits_repository_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:habit_tracker/core/database/habit_database.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
+import 'package:habit_tracker/features/habits/domain/domain.dart';
+
+void main() {
+  late Directory tempDir;
+  late HabitDatabase database;
+  late HabitsRepository repository;
+  late HiveInterface hive;
+
+  Habit buildHabit(int seed) {
+    return Habit(
+      id: 'habit_$seed',
+      name: 'Habit $seed',
+      emoji: '🔥',
+      color: 0xFF000000 + seed,
+      days: <int>[seed % 7],
+      reminderId: 'reminder_$seed',
+      reminderTime: '08:0$seed',
+      bestStreak: seed,
+      currentStreak: seed ~/ 2,
+      lastChecked: null,
+    );
+  }
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('habit_db_test');
+    hive = Hive;
+    database = HabitDatabase(
+      hive: hive,
+      initializer: () async {
+        hive.init(tempDir.path);
+      },
+    );
+    await database.initialize();
+    repository = HabitsRepository(database);
+  });
+
+  tearDown(() async {
+    await database.close();
+    await hive.deleteFromDisk();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('fetchHabits returns stored habits', () async {
+    final habit = buildHabit(1);
+    await repository.saveHabit(habit);
+
+    final habits = await repository.fetchHabits();
+
+    expect(habits, <Habit>[habit]);
+  });
+
+  test('findById returns the habit when it exists', () async {
+    final habit = buildHabit(2);
+    await repository.saveHabit(habit);
+
+    final result = await repository.findById(habit.id);
+
+    expect(result, habit);
+  });
+
+  test('findById returns null when habit does not exist', () async {
+    final result = await repository.findById('missing');
+
+    expect(result, isNull);
+  });
+
+  test('deleteHabit removes the habit from storage', () async {
+    final habit = buildHabit(3);
+    await repository.saveHabit(habit);
+
+    await repository.deleteHabit(habit.id);
+
+    final habits = await repository.fetchHabits();
+    expect(habits, isEmpty);
+  });
+
+  test('watchHabits emits updates when habits change', () async {
+    final habitA = buildHabit(4);
+    final habitB = buildHabit(5);
+
+    final expectation = expectLater(
+      repository.watchHabits(),
+      emitsInOrder(<Object?>[
+        <Habit>[],
+        <Habit>[habitA],
+        <Habit>[habitA, habitB],
+        <Habit>[habitB],
+      ]),
+    );
+
+    await repository.saveHabit(habitA);
+    await repository.saveHabit(habitB);
+    await repository.deleteHabit(habitA.id);
+
+    await expectation;
+  });
+}


### PR DESCRIPTION
## Summary
- add Hive-powered repositories for habits and habit entries with Riverpod providers
- cover repository CRUD and streaming behaviour with unit tests against HabitDatabase

## Testing
- fvm flutter analyze
- fvm flutter test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e2d49cc78883258b5af93a3a2cf952