### PR TITLE
feat: add onboarding experience with starter habits

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -17,6 +17,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        isCoreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = "17"
@@ -98,4 +99,5 @@ flutter {
 dependencies {
     implementation("com.google.android.play:core:1.10.3")
     implementation("com.google.android.play:core-ktx:1.8.1")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -2,17 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:habit_tracker/features/habits/presentation/screens/home_screen.dart';
+import 'package:habit_tracker/features/onboarding/presentation/screens/onboarding_screen.dart';
 import 'package:habit_tracker/features/settings/presentation/screens/settings_screen.dart';
 
 GoRouter createAppRouter({
   List<NavigatorObserver> observers = const [],
   GlobalKey<NavigatorState>? navigatorKey,
+  bool hasCompletedOnboarding = true,
 }) {
   return GoRouter(
     navigatorKey: navigatorKey,
-    initialLocation: '/',
+    initialLocation: hasCompletedOnboarding ? '/' : '/onboarding',
     observers: observers,
     routes: [
+      GoRoute(
+        path: '/onboarding',
+        name: 'onboarding',
+        builder: (context, state) => const OnboardingScreen(),
+      ),
       GoRoute(
         path: '/',
         name: 'home',

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -23,8 +23,10 @@ class NotificationService {
             MacOSFlutterLocalNotificationsPlugin>();
 
     final androidResult = await androidImpl?.requestNotificationsPermission();
-    if (androidResult == true) {
-      granted = true;
+    if (androidImpl != null) {
+      if (androidResult == null || androidResult == true) {
+        granted = true;
+      }
     }
 
     final iosResult = await iosImpl?.requestPermissions(

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class NotificationService {
+  NotificationService({FlutterLocalNotificationsPlugin? plugin})
+      : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  FlutterLocalNotificationsPlugin get plugin => _plugin;
+
+  Future<bool> requestPermission() async {
+    var granted = false;
+
+    final androidImpl = _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    final iosImpl = _plugin
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>();
+    final macImpl = _plugin
+        .resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin>();
+
+    final androidResult = await androidImpl?.requestNotificationsPermission();
+    if (androidResult == true) {
+      granted = true;
+    }
+
+    final iosResult = await iosImpl?.requestPermissions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+    if (iosResult == true) {
+      granted = true;
+    }
+
+    final macResult = await macImpl?.requestPermissions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+    if (macResult == true) {
+      granted = true;
+    }
+
+    return granted;
+  }
+}
+
+final notificationServiceProvider = Provider<NotificationService>((ref) {
+  return NotificationService();
+});

--- a/lib/features/onboarding/application/onboarding_controller.dart
+++ b/lib/features/onboarding/application/onboarding_controller.dart
@@ -39,7 +39,10 @@ class OnboardingController extends StateNotifier<OnboardingState> {
     state = state.copyWith(pageIndex: index);
   }
 
-  void skipToNotifications() {
+  Future<void> skipToNotifications() async {
+    if (state.permissionStatus == NotificationPermissionStatus.idle) {
+      await declineNotifications();
+    }
     setPageIndex(2);
   }
 

--- a/lib/features/onboarding/application/onboarding_controller.dart
+++ b/lib/features/onboarding/application/onboarding_controller.dart
@@ -1,0 +1,151 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../habits/data/repositories/habits_repository.dart';
+import '../../habits/domain/domain.dart';
+import '../../settings/application/controllers/notification_settings_controller.dart';
+import '../../settings/application/providers/notification_settings_provider.dart';
+import '../../../core/services/notification_service.dart';
+import 'onboarding_state.dart';
+import 'starter_habit_template.dart';
+
+class OnboardingController extends StateNotifier<OnboardingState> {
+  OnboardingController({
+    required HabitsRepository habitsRepository,
+    required NotificationService notificationService,
+    required NotificationSettingsController notificationSettings,
+    SharedPreferences? preferences,
+  })  : _habitsRepository = habitsRepository,
+        _notificationService = notificationService,
+        _notificationSettings = notificationSettings,
+        _providedPrefs = preferences,
+        super(const OnboardingState());
+
+  static const hasOnboardedKey = 'has_onboarded';
+
+  final HabitsRepository _habitsRepository;
+  final NotificationService _notificationService;
+  final NotificationSettingsController _notificationSettings;
+  final SharedPreferences? _providedPrefs;
+
+  SharedPreferences? _prefs;
+
+  Future<SharedPreferences> _prefsInstance() async {
+    return _prefs ??= _providedPrefs ?? await SharedPreferences.getInstance();
+  }
+
+  void setPageIndex(int index) {
+    if (index == state.pageIndex) return;
+    state = state.copyWith(pageIndex: index);
+  }
+
+  void skipToNotifications() {
+    setPageIndex(2);
+  }
+
+  void toggleHabit(StarterHabitTemplate template, String label) {
+    final current = Map<String, String>.from(state.selectedHabits);
+    if (current.containsKey(template.id)) {
+      current.remove(template.id);
+      state = state.copyWith(selectedHabits: current);
+      return;
+    }
+
+    if (current.length >= 3) {
+      return;
+    }
+
+    current[template.id] = label;
+    state = state.copyWith(selectedHabits: current);
+  }
+
+  Future<void> enableNotifications() async {
+    if (state.isRequestingPermission) return;
+    state = state.copyWith(isRequestingPermission: true, errorMessage: null);
+
+    try {
+      final granted = await _notificationService.requestPermission();
+      await _notificationSettings.setEnabled(granted);
+      state = state.copyWith(
+        permissionStatus: granted
+            ? NotificationPermissionStatus.granted
+            : NotificationPermissionStatus.denied,
+        isRequestingPermission: false,
+      );
+    } catch (error) {
+      state = state.copyWith(
+        errorMessage: error.toString(),
+        permissionStatus: NotificationPermissionStatus.denied,
+        isRequestingPermission: false,
+      );
+    }
+  }
+
+  Future<void> declineNotifications() async {
+    await _notificationSettings.setEnabled(false);
+    state = state.copyWith(
+      permissionStatus: NotificationPermissionStatus.denied,
+      errorMessage: null,
+    );
+  }
+
+  Future<bool> completeOnboarding() async {
+    if (state.isSaving) return false;
+    state = state.copyWith(isSaving: true, errorMessage: null);
+
+    try {
+      await _createSelectedHabits();
+      final prefs = await _prefsInstance();
+      await prefs.setBool(hasOnboardedKey, true);
+      state = state.copyWith(isSaving: false);
+      return true;
+    } catch (error) {
+      state = state.copyWith(
+        isSaving: false,
+        errorMessage: error.toString(),
+      );
+      return false;
+    }
+  }
+
+  Future<void> _createSelectedHabits() async {
+    if (state.selectedHabits.isEmpty) return;
+    final templates = {
+      for (final template in starterHabitTemplates) template.id: template,
+    };
+    var counter = 0;
+    final timestamp = DateTime.now().microsecondsSinceEpoch;
+    for (final entry in state.selectedHabits.entries) {
+      final template = templates[entry.key];
+      if (template == null) continue;
+      final habitId =
+          'starter_${template.id}_${timestamp}_${counter.toRadixString(16)}';
+      counter += 1;
+      final habit = Habit(
+        id: habitId,
+        name: entry.value,
+        emoji: template.emoji,
+        color: template.color,
+        days: List<int>.generate(7, (index) => index),
+        reminderId: habitId,
+        reminderTime: '08:00',
+        bestStreak: 0,
+        currentStreak: 0,
+      );
+      await _habitsRepository.saveHabit(habit);
+    }
+  }
+}
+
+final onboardingControllerProvider =
+    StateNotifierProvider<OnboardingController, OnboardingState>((ref) {
+  final habitsRepository = ref.watch(habitsRepositoryProvider);
+  final notificationService = ref.watch(notificationServiceProvider);
+  final notificationSettings = ref.watch(notificationSettingsProvider);
+
+  return OnboardingController(
+    habitsRepository: habitsRepository,
+    notificationService: notificationService,
+    notificationSettings: notificationSettings,
+  );
+});

--- a/lib/features/onboarding/application/onboarding_state.dart
+++ b/lib/features/onboarding/application/onboarding_state.dart
@@ -1,0 +1,79 @@
+enum NotificationPermissionStatus { idle, granted, denied }
+
+class OnboardingState {
+  const OnboardingState({
+    this.pageIndex = 0,
+    Map<String, String>? selectedHabits,
+    this.isSaving = false,
+    this.errorMessage,
+    this.permissionStatus = NotificationPermissionStatus.idle,
+    this.isRequestingPermission = false,
+  }) : selectedHabits = selectedHabits ?? const <String, String>{};
+
+  final int pageIndex;
+  final Map<String, String> selectedHabits;
+  final bool isSaving;
+  final String? errorMessage;
+  final NotificationPermissionStatus permissionStatus;
+  final bool isRequestingPermission;
+
+  bool get hasNotificationChoice =>
+      permissionStatus != NotificationPermissionStatus.idle;
+
+  bool get canContinue => selectedHabits.isNotEmpty;
+
+  bool get canFinish => !isSaving && hasNotificationChoice;
+
+  OnboardingState copyWith({
+    int? pageIndex,
+    Map<String, String>? selectedHabits,
+    bool? isSaving,
+    String? errorMessage,
+    NotificationPermissionStatus? permissionStatus,
+    bool? isRequestingPermission,
+  }) {
+    return OnboardingState(
+      pageIndex: pageIndex ?? this.pageIndex,
+      selectedHabits: selectedHabits ?? this.selectedHabits,
+      isSaving: isSaving ?? this.isSaving,
+      errorMessage: errorMessage,
+      permissionStatus: permissionStatus ?? this.permissionStatus,
+      isRequestingPermission:
+      isRequestingPermission ?? this.isRequestingPermission,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is OnboardingState &&
+        other.pageIndex == pageIndex &&
+        _mapEquals(other.selectedHabits, selectedHabits) &&
+        other.isSaving == isSaving &&
+        other.errorMessage == errorMessage &&
+        other.permissionStatus == permissionStatus &&
+        other.isRequestingPermission == isRequestingPermission;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        pageIndex,
+        Object.hashAll(selectedHabits.entries
+            .map((entry) => Object.hash(entry.key, entry.value))),
+        isSaving,
+        errorMessage,
+        permissionStatus,
+        isRequestingPermission,
+      );
+}
+
+bool _mapEquals(Map<String, String> a, Map<String, String> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (final key in a.keys) {
+    if (!b.containsKey(key) || b[key] != a[key]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/lib/features/onboarding/application/starter_habit_template.dart
+++ b/lib/features/onboarding/application/starter_habit_template.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../../../l10n/app_localizations.dart';
+
+@immutable
+class StarterHabitTemplate {
+  const StarterHabitTemplate({
+    required this.id,
+    required this.emoji,
+    required this.color,
+  });
+
+  final String id;
+  final String emoji;
+  final int color;
+
+  String label(AppLocalizations l10n) {
+    switch (id) {
+      case 'meditate':
+        return l10n.onboardingHabitMeditate;
+      case 'walk':
+        return l10n.onboardingHabitWalk;
+      case 'hydrate':
+        return l10n.onboardingHabitHydrate;
+      case 'journal':
+        return l10n.onboardingHabitJournal;
+      case 'stretch':
+        return l10n.onboardingHabitStretch;
+      case 'read':
+        return l10n.onboardingHabitRead;
+      default:
+        return id;
+    }
+  }
+}
+
+const starterHabitTemplates = <StarterHabitTemplate>[
+  StarterHabitTemplate(
+    id: 'meditate',
+    emoji: '🧘',
+    color: 0xFF7C83FD,
+  ),
+  StarterHabitTemplate(
+    id: 'walk',
+    emoji: '🚶',
+    color: 0xFF00B894,
+  ),
+  StarterHabitTemplate(
+    id: 'hydrate',
+    emoji: '💧',
+    color: 0xFF40C4FF,
+  ),
+  StarterHabitTemplate(
+    id: 'journal',
+    emoji: '📓',
+    color: 0xFFFFB347,
+  ),
+  StarterHabitTemplate(
+    id: 'stretch',
+    emoji: '🤸',
+    color: 0xFFF06292,
+  ),
+  StarterHabitTemplate(
+    id: 'read',
+    emoji: '📚',
+    color: 0xFF6C5CE7,
+  ),
+];

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -256,7 +256,6 @@ class _NotificationsPage extends ConsumerWidget {
                       ),
                     ),
                   )
-                )
                 : Text(l10n.onboardingEnableReminders),
           ),
         ),

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -1,0 +1,416 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/localization/l10n_extensions.dart';
+import '../../application/onboarding_controller.dart';
+import '../../application/onboarding_state.dart';
+import '../../application/starter_habit_template.dart';
+
+class OnboardingScreen extends ConsumerStatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  late final PageController _pageController;
+  ProviderSubscription<OnboardingState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+    _subscription = ref.listenManual<OnboardingState>(
+      onboardingControllerProvider,
+      (previous, next) {
+        if (!_pageController.hasClients) {
+          return;
+        }
+        final currentPage =
+            _pageController.page?.round() ?? _pageController.initialPage;
+        if (currentPage == next.pageIndex) {
+          return;
+        }
+        _pageController.animateToPage(
+          next.pageIndex,
+          duration: const Duration(milliseconds: 350),
+          curve: Curves.easeInOut,
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(onboardingControllerProvider);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+    final l10n = context.l10n;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          child: Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  if (state.pageIndex < 2)
+                    TextButton(
+                      onPressed: () {
+                        controller.skipToNotifications();
+                      },
+                      child: Text(l10n.onboardingSkip),
+                    ),
+                ],
+              ),
+              Expanded(
+                child: PageView(
+                  controller: _pageController,
+                  onPageChanged: controller.setPageIndex,
+                  physics: const ClampingScrollPhysics(),
+                  children: [
+                    _WelcomePage(
+                      onGetStarted: () => controller.setPageIndex(1),
+                    ),
+                    _HabitSelectionPage(state: state),
+                    _NotificationsPage(state: state),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              _ProgressDots(currentIndex: state.pageIndex, total: 3),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WelcomePage extends ConsumerWidget {
+  const _WelcomePage({required this.onGetStarted});
+
+  final VoidCallback onGetStarted;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Spacer(),
+        Text(
+          l10n.appTitle,
+          style: theme.textTheme.displaySmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 16),
+        Text(
+          l10n.onboardingTagline,
+          style: theme.textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        const Spacer(),
+        ElevatedButton(
+          onPressed: onGetStarted,
+          child: Text(l10n.onboardingGetStarted),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          l10n.onboardingGoal,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _HabitSelectionPage extends ConsumerWidget {
+  const _HabitSelectionPage({required this.state});
+
+  final OnboardingState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.onboardingHabitsTitle,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.onboardingHabitsSubtitle,
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 16),
+        Expanded(
+          child: SingleChildScrollView(
+            child: Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                for (final template in starterHabitTemplates)
+                  _StarterHabitCard(
+                    template: template,
+                    label: template.label(l10n),
+                    selected: state.selectedHabits.containsKey(template.id),
+                    onTap: () => controller.toggleHabit(
+                      template,
+                      template.label(l10n),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        ElevatedButton(
+          onPressed: state.canContinue
+              ? () => controller.setPageIndex(2)
+              : null,
+          child: Text(l10n.onboardingContinue),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.onboardingSelectionHint,
+          style: theme.textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}
+
+class _NotificationsPage extends ConsumerWidget {
+  const _NotificationsPage({required this.state});
+
+  final OnboardingState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final controller = ref.read(onboardingControllerProvider.notifier);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          l10n.onboardingNotificationsTitle,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          l10n.onboardingNotificationsSubtitle,
+          style: theme.textTheme.bodyMedium,
+        ),
+        const SizedBox(height: 24),
+        ElevatedButton(
+          onPressed: state.isRequestingPermission
+              ? null
+              : () => controller.enableNotifications(),
+          child: state.isRequestingPermission
+              ? SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      theme.colorScheme.onPrimary,
+                    ),
+                  ),
+                )
+              : Text(l10n.onboardingEnableReminders),
+        ),
+        TextButton(
+          onPressed: state.isRequestingPermission
+              ? null
+              : () => controller.declineNotifications(),
+          child: Text(l10n.onboardingMaybeLater),
+        ),
+        const SizedBox(height: 16),
+        AnimatedSwitcher(
+          duration: const Duration(milliseconds: 250),
+          child: state.hasNotificationChoice
+              ? Column(
+                  key: ValueKey(state.permissionStatus),
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      state.permissionStatus ==
+                              NotificationPermissionStatus.granted
+                          ? l10n.onboardingNotificationsGranted
+                          : l10n.onboardingNotificationsDenied,
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      l10n.onboardingFinishTitle,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                )
+              : const SizedBox.shrink(),
+        ),
+        const Spacer(),
+        if (state.errorMessage != null) ...[
+          Text(
+            l10n.onboardingError(state.errorMessage!),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.error,
+            ),
+          ),
+          const SizedBox(height: 12),
+        ],
+        ElevatedButton(
+          onPressed: state.canFinish
+              ? () async {
+                  final success = await controller.completeOnboarding();
+                  if (!context.mounted || !success) {
+                    return;
+                  }
+                  if (context.mounted) {
+                    context.goNamed('home');
+                  }
+                }
+              : null,
+          child: Text(l10n.onboardingFinishCta),
+        ),
+      ],
+    );
+  }
+}
+
+class _StarterHabitCard extends StatelessWidget {
+  const _StarterHabitCard({
+    required this.template,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final StarterHabitTemplate template;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderColor = selected
+        ? theme.colorScheme.primary
+        : theme.colorScheme.outlineVariant;
+
+    return Semantics(
+      label: label,
+      button: true,
+      toggled: selected,
+      child: GestureDetector(
+        onTap: onTap,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          width: 140,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceContainerHighest,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(color: borderColor, width: 2),
+            boxShadow: [
+              if (selected)
+                BoxShadow(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.2),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                template.emoji,
+                style: const TextStyle(fontSize: 40),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                label,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              AnimatedOpacity(
+                opacity: selected ? 1 : 0,
+                duration: const Duration(milliseconds: 200),
+                child: Icon(
+                  Icons.check_circle,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProgressDots extends StatelessWidget {
+  const _ProgressDots({
+    required this.currentIndex,
+    required this.total,
+  });
+
+  final int currentIndex;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(total, (index) {
+        final isActive = index == currentIndex;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: isActive ? 20 : 8,
+          height: 8,
+          decoration: BoxDecoration(
+            color: isActive
+                ? theme.colorScheme.primary
+                : theme.colorScheme.outlineVariant,
+            borderRadius: BorderRadius.circular(4),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -152,23 +152,27 @@ class _HabitSelectionPage extends ConsumerWidget {
     final controller = ref.read(onboardingControllerProvider.notifier);
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
           l10n.onboardingHabitsTitle,
           style: theme.textTheme.headlineSmall?.copyWith(
             fontWeight: FontWeight.bold,
           ),
+          textAlign: TextAlign.center,
         ),
         const SizedBox(height: 8),
         Text(
           l10n.onboardingHabitsSubtitle,
           style: theme.textTheme.bodyMedium,
+          textAlign: TextAlign.center,
         ),
         const SizedBox(height: 16),
         Expanded(
           child: SingleChildScrollView(
             child: Wrap(
+              alignment: WrapAlignment.center,
+              runAlignment: WrapAlignment.center,
               spacing: 12,
               runSpacing: 12,
               children: [
@@ -187,16 +191,20 @@ class _HabitSelectionPage extends ConsumerWidget {
           ),
         ),
         const SizedBox(height: 16),
-        ElevatedButton(
-          onPressed: state.canContinue
-              ? () => controller.setPageIndex(2)
-              : null,
-          child: Text(l10n.onboardingContinue),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: state.canContinue
+                ? () => controller.setPageIndex(2)
+                : null,
+            child: Text(l10n.onboardingContinue),
+          ),
         ),
         const SizedBox(height: 8),
         Text(
           l10n.onboardingSelectionHint,
           style: theme.textTheme.bodySmall,
+          textAlign: TextAlign.center,
         ),
       ],
     );
@@ -215,36 +223,42 @@ class _NotificationsPage extends ConsumerWidget {
     final controller = ref.read(onboardingControllerProvider.notifier);
 
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
           l10n.onboardingNotificationsTitle,
           style: theme.textTheme.headlineSmall?.copyWith(
             fontWeight: FontWeight.bold,
           ),
+          textAlign: TextAlign.center,
         ),
         const SizedBox(height: 8),
         Text(
           l10n.onboardingNotificationsSubtitle,
           style: theme.textTheme.bodyMedium,
+          textAlign: TextAlign.center,
         ),
         const SizedBox(height: 24),
-        ElevatedButton(
-          onPressed: state.isRequestingPermission
-              ? null
-              : () => controller.enableNotifications(),
-          child: state.isRequestingPermission
-              ? SizedBox(
-                  height: 20,
-                  width: 20,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    valueColor: AlwaysStoppedAnimation<Color>(
-                      theme.colorScheme.onPrimary,
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: state.isRequestingPermission
+                ? null
+                : () => controller.enableNotifications(),
+            child: state.isRequestingPermission
+                ? SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(
+                        theme.colorScheme.onPrimary,
+                      ),
                     ),
-                  ),
+                  )
                 )
-              : Text(l10n.onboardingEnableReminders),
+                : Text(l10n.onboardingEnableReminders),
+          ),
         ),
         TextButton(
           onPressed: state.isRequestingPermission
@@ -258,7 +272,7 @@ class _NotificationsPage extends ConsumerWidget {
           child: state.hasNotificationChoice
               ? Column(
                   key: ValueKey(state.permissionStatus),
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Text(
                       state.permissionStatus ==
@@ -266,6 +280,7 @@ class _NotificationsPage extends ConsumerWidget {
                           ? l10n.onboardingNotificationsGranted
                           : l10n.onboardingNotificationsDenied,
                       style: theme.textTheme.bodyMedium,
+                      textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 12),
                     Text(
@@ -273,6 +288,7 @@ class _NotificationsPage extends ConsumerWidget {
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.bold,
                       ),
+                      textAlign: TextAlign.center,
                     ),
                   ],
                 )
@@ -288,19 +304,22 @@ class _NotificationsPage extends ConsumerWidget {
           ),
           const SizedBox(height: 12),
         ],
-        ElevatedButton(
-          onPressed: state.canFinish
-              ? () async {
-                  final success = await controller.completeOnboarding();
-                  if (!context.mounted || !success) {
-                    return;
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            onPressed: state.canFinish
+                ? () async {
+                    final success = await controller.completeOnboarding();
+                    if (!context.mounted || !success) {
+                      return;
+                    }
+                    if (context.mounted) {
+                      context.goNamed('home');
+                    }
                   }
-                  if (context.mounted) {
-                    context.goNamed('home');
-                  }
-                }
-              : null,
-          child: Text(l10n.onboardingFinishCta),
+                : null,
+            child: Text(l10n.onboardingFinishCta),
+          ),
         ),
       ],
     );

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -71,5 +71,36 @@
     }
   },
   "releaseNotesTitle": "Release Notes",
-  "privacyPolicyTitle": "Privacy Policy"
+  "privacyPolicyTitle": "Privacy Policy",
+  "onboardingSkip": "Skip",
+  "onboardingTagline": "Build better routines one day at a time",
+  "onboardingGetStarted": "Get Started",
+  "onboardingGoal": "Track up to three daily habits",
+  "onboardingHabitsTitle": "Choose your starter habits",
+  "onboardingHabitsSubtitle": "Pick up to three habits to jump-start your routine.",
+  "onboardingContinue": "Continue",
+  "onboardingSelectionHint": "You can add or edit habits later from the dashboard.",
+  "onboardingNotificationsTitle": "Stay on track with reminders",
+  "onboardingNotificationsSubtitle": "Enable reminders so we can nudge you to keep your streaks.",
+  "onboardingEnableReminders": "Enable Reminders",
+  "onboardingMaybeLater": "Later",
+  "onboardingNotificationsGranted": "Reminders are on! We'll send a gentle nudge each day.",
+  "onboardingNotificationsDenied": "No worries! You can turn reminders on later from Settings.",
+  "onboardingFinishTitle": "You're ready to start!",
+  "onboardingFinishCta": "Go to Dashboard",
+  "onboardingError": "Something went wrong: {message}",
+  "@onboardingError": {
+    "description": "Displayed when saving onboarding data fails.",
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "onboardingHabitMeditate": "Meditate",
+  "onboardingHabitWalk": "Walk",
+  "onboardingHabitHydrate": "Drink water",
+  "onboardingHabitJournal": "Journal",
+  "onboardingHabitStretch": "Stretch",
+  "onboardingHabitRead": "Read"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -71,5 +71,36 @@
     }
   },
   "releaseNotesTitle": "Notes de version",
-  "privacyPolicyTitle": "Politique de confidentialité"
+  "privacyPolicyTitle": "Politique de confidentialité",
+  "onboardingSkip": "Ignorer",
+  "onboardingTagline": "Construisez de meilleures routines un jour à la fois",
+  "onboardingGetStarted": "Commencer",
+  "onboardingGoal": "Suivez jusqu'à trois habitudes quotidiennes",
+  "onboardingHabitsTitle": "Choisissez vos habitudes de départ",
+  "onboardingHabitsSubtitle": "Sélectionnez jusqu'à trois habitudes pour lancer votre routine.",
+  "onboardingContinue": "Continuer",
+  "onboardingSelectionHint": "Vous pourrez ajouter ou modifier des habitudes plus tard depuis le tableau de bord.",
+  "onboardingNotificationsTitle": "Restez sur la bonne voie avec des rappels",
+  "onboardingNotificationsSubtitle": "Activez les rappels pour que nous puissions vous encourager à tenir vos séries.",
+  "onboardingEnableReminders": "Activer les rappels",
+  "onboardingMaybeLater": "Plus tard",
+  "onboardingNotificationsGranted": "Les rappels sont activés ! Nous vous enverrons un petit rappel chaque jour.",
+  "onboardingNotificationsDenied": "Pas de souci ! Vous pourrez activer les rappels plus tard dans les paramètres.",
+  "onboardingFinishTitle": "Vous êtes prêt·e à commencer !",
+  "onboardingFinishCta": "Aller au tableau de bord",
+  "onboardingError": "Un problème est survenu : {message}",
+  "@onboardingError": {
+    "description": "Affiché lorsque l'enregistrement de l'onboarding échoue.",
+    "placeholders": {
+      "message": {
+        "type": "String"
+      }
+    }
+  },
+  "onboardingHabitMeditate": "Méditer",
+  "onboardingHabitWalk": "Marcher",
+  "onboardingHabitHydrate": "Boire de l'eau",
+  "onboardingHabitJournal": "Écrire dans mon journal",
+  "onboardingHabitStretch": "M'étirer",
+  "onboardingHabitRead": "Lire"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -367,6 +367,144 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Privacy Policy'**
   String get privacyPolicyTitle;
+
+  /// No description provided for @onboardingSkip.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip'**
+  String get onboardingSkip;
+
+  /// No description provided for @onboardingTagline.
+  ///
+  /// In en, this message translates to:
+  /// **'Build better routines one day at a time'**
+  String get onboardingTagline;
+
+  /// No description provided for @onboardingGetStarted.
+  ///
+  /// In en, this message translates to:
+  /// **'Get Started'**
+  String get onboardingGetStarted;
+
+  /// No description provided for @onboardingGoal.
+  ///
+  /// In en, this message translates to:
+  /// **'Track up to three daily habits'**
+  String get onboardingGoal;
+
+  /// No description provided for @onboardingHabitsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose your starter habits'**
+  String get onboardingHabitsTitle;
+
+  /// No description provided for @onboardingHabitsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick up to three habits to jump-start your routine.'**
+  String get onboardingHabitsSubtitle;
+
+  /// No description provided for @onboardingContinue.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get onboardingContinue;
+
+  /// No description provided for @onboardingSelectionHint.
+  ///
+  /// In en, this message translates to:
+  /// **'You can add or edit habits later from the dashboard.'**
+  String get onboardingSelectionHint;
+
+  /// No description provided for @onboardingNotificationsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Stay on track with reminders'**
+  String get onboardingNotificationsTitle;
+
+  /// No description provided for @onboardingNotificationsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable reminders so we can nudge you to keep your streaks.'**
+  String get onboardingNotificationsSubtitle;
+
+  /// No description provided for @onboardingEnableReminders.
+  ///
+  /// In en, this message translates to:
+  /// **'Enable Reminders'**
+  String get onboardingEnableReminders;
+
+  /// No description provided for @onboardingMaybeLater.
+  ///
+  /// In en, this message translates to:
+  /// **'Later'**
+  String get onboardingMaybeLater;
+
+  /// No description provided for @onboardingNotificationsGranted.
+  ///
+  /// In en, this message translates to:
+  /// **'Reminders are on! We\'ll send a gentle nudge each day.'**
+  String get onboardingNotificationsGranted;
+
+  /// No description provided for @onboardingNotificationsDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'No worries! You can turn reminders on later from Settings.'**
+  String get onboardingNotificationsDenied;
+
+  /// No description provided for @onboardingFinishTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re ready to start!'**
+  String get onboardingFinishTitle;
+
+  /// No description provided for @onboardingFinishCta.
+  ///
+  /// In en, this message translates to:
+  /// **'Go to Dashboard'**
+  String get onboardingFinishCta;
+
+  /// Displayed when saving onboarding data fails.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong: {message}'**
+  String onboardingError(String message);
+
+  /// No description provided for @onboardingHabitMeditate.
+  ///
+  /// In en, this message translates to:
+  /// **'Meditate'**
+  String get onboardingHabitMeditate;
+
+  /// No description provided for @onboardingHabitWalk.
+  ///
+  /// In en, this message translates to:
+  /// **'Walk'**
+  String get onboardingHabitWalk;
+
+  /// No description provided for @onboardingHabitHydrate.
+  ///
+  /// In en, this message translates to:
+  /// **'Drink water'**
+  String get onboardingHabitHydrate;
+
+  /// No description provided for @onboardingHabitJournal.
+  ///
+  /// In en, this message translates to:
+  /// **'Journal'**
+  String get onboardingHabitJournal;
+
+  /// No description provided for @onboardingHabitStretch.
+  ///
+  /// In en, this message translates to:
+  /// **'Stretch'**
+  String get onboardingHabitStretch;
+
+  /// No description provided for @onboardingHabitRead.
+  ///
+  /// In en, this message translates to:
+  /// **'Read'**
+  String get onboardingHabitRead;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -154,4 +154,80 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get privacyPolicyTitle => 'Privacy Policy';
+
+  @override
+  String get onboardingSkip => 'Skip';
+
+  @override
+  String get onboardingTagline => 'Build better routines one day at a time';
+
+  @override
+  String get onboardingGetStarted => 'Get Started';
+
+  @override
+  String get onboardingGoal => 'Track up to three daily habits';
+
+  @override
+  String get onboardingHabitsTitle => 'Choose your starter habits';
+
+  @override
+  String get onboardingHabitsSubtitle =>
+      'Pick up to three habits to jump-start your routine.';
+
+  @override
+  String get onboardingContinue => 'Continue';
+
+  @override
+  String get onboardingSelectionHint =>
+      'You can add or edit habits later from the dashboard.';
+
+  @override
+  String get onboardingNotificationsTitle => 'Stay on track with reminders';
+
+  @override
+  String get onboardingNotificationsSubtitle =>
+      'Enable reminders so we can nudge you to keep your streaks.';
+
+  @override
+  String get onboardingEnableReminders => 'Enable Reminders';
+
+  @override
+  String get onboardingMaybeLater => 'Later';
+
+  @override
+  String get onboardingNotificationsGranted =>
+      'Reminders are on! We\'ll send a gentle nudge each day.';
+
+  @override
+  String get onboardingNotificationsDenied =>
+      'No worries! You can turn reminders on later from Settings.';
+
+  @override
+  String get onboardingFinishTitle => 'You\'re ready to start!';
+
+  @override
+  String get onboardingFinishCta => 'Go to Dashboard';
+
+  @override
+  String onboardingError(String message) {
+    return 'Something went wrong: $message';
+  }
+
+  @override
+  String get onboardingHabitMeditate => 'Meditate';
+
+  @override
+  String get onboardingHabitWalk => 'Walk';
+
+  @override
+  String get onboardingHabitHydrate => 'Drink water';
+
+  @override
+  String get onboardingHabitJournal => 'Journal';
+
+  @override
+  String get onboardingHabitStretch => 'Stretch';
+
+  @override
+  String get onboardingHabitRead => 'Read';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -160,4 +160,82 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get privacyPolicyTitle => 'Politique de confidentialité';
+
+  @override
+  String get onboardingSkip => 'Ignorer';
+
+  @override
+  String get onboardingTagline =>
+      'Construisez de meilleures routines un jour à la fois';
+
+  @override
+  String get onboardingGetStarted => 'Commencer';
+
+  @override
+  String get onboardingGoal => 'Suivez jusqu\'à trois habitudes quotidiennes';
+
+  @override
+  String get onboardingHabitsTitle => 'Choisissez vos habitudes de départ';
+
+  @override
+  String get onboardingHabitsSubtitle =>
+      'Sélectionnez jusqu\'à trois habitudes pour lancer votre routine.';
+
+  @override
+  String get onboardingContinue => 'Continuer';
+
+  @override
+  String get onboardingSelectionHint =>
+      'Vous pourrez ajouter ou modifier des habitudes plus tard depuis le tableau de bord.';
+
+  @override
+  String get onboardingNotificationsTitle =>
+      'Restez sur la bonne voie avec des rappels';
+
+  @override
+  String get onboardingNotificationsSubtitle =>
+      'Activez les rappels pour que nous puissions vous encourager à tenir vos séries.';
+
+  @override
+  String get onboardingEnableReminders => 'Activer les rappels';
+
+  @override
+  String get onboardingMaybeLater => 'Plus tard';
+
+  @override
+  String get onboardingNotificationsGranted =>
+      'Les rappels sont activés ! Nous vous enverrons un petit rappel chaque jour.';
+
+  @override
+  String get onboardingNotificationsDenied =>
+      'Pas de souci ! Vous pourrez activer les rappels plus tard dans les paramètres.';
+
+  @override
+  String get onboardingFinishTitle => 'Vous êtes prêt·e à commencer !';
+
+  @override
+  String get onboardingFinishCta => 'Aller au tableau de bord';
+
+  @override
+  String onboardingError(String message) {
+    return 'Un problème est survenu : $message';
+  }
+
+  @override
+  String get onboardingHabitMeditate => 'Méditer';
+
+  @override
+  String get onboardingHabitWalk => 'Marcher';
+
+  @override
+  String get onboardingHabitHydrate => 'Boire de l\'eau';
+
+  @override
+  String get onboardingHabitJournal => 'Écrire dans mon journal';
+
+  @override
+  String get onboardingHabitStretch => 'M\'étirer';
+
+  @override
+  String get onboardingHabitRead => 'Lire';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'firebase_options_dev.dart' as dev;
 import 'firebase_options_staging.dart' as stg;
@@ -18,6 +19,8 @@ import 'core/router/app_router.dart';
 import 'core/telemetry/controllers/telemetry_controller.dart';
 import 'core/telemetry/providers/telemetry_provider.dart';
 import 'core/database/habit_database.dart';
+import 'core/services/notification_service.dart';
+import 'features/onboarding/application/onboarding_controller.dart';
 import 'features/settings/application/controllers/theme_controller.dart';
 import 'features/settings/application/controllers/language_controller.dart';
 import 'features/settings/application/providers/theme_provider.dart';
@@ -72,6 +75,11 @@ Future<void> main() async {
   final notificationSettingsController = NotificationSettingsController();
   await notificationSettingsController.load();
 
+  final prefs = await SharedPreferences.getInstance();
+  final hasOnboarded =
+      prefs.getBool(OnboardingController.hasOnboardedKey) ?? false;
+  final notificationService = NotificationService();
+
   if (enableFirebase) {
     // Forward Flutter framework errors
     FlutterError.onError = (FlutterErrorDetails details) {
@@ -109,6 +117,7 @@ Future<void> main() async {
   final router = createAppRouter(
     observers: observers,
     navigatorKey: rootNavigatorKey,
+    hasCompletedOnboarding: hasOnboarded,
   );
 
   runApp(
@@ -121,6 +130,7 @@ Future<void> main() async {
           (ref) => notificationSettingsController,
         ),
         habitDatabaseProvider.overrideWithValue(database),
+        notificationServiceProvider.overrideWithValue(notificationService),
       ],
       child: HabitTrackerApp(
         router: router,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   fake_async:
     dependency: transitive
     description:
@@ -230,6 +238,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "17.2.4"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.2.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -642,6 +674,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   http: ^1.2.2
   hive: ^2.2.3
   hive_flutter: ^1.1.0
+  flutter_local_notifications: ^17.2.1
   flutter_localizations:
     sdk: flutter
   flutter_html: ^3.0.0-beta.2

--- a/test/core/services/notification_service_test.dart
+++ b/test/core/services/notification_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:habit_tracker/core/services/notification_service.dart';
+
+class _MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
+
+class _MockAndroidFlutterLocalNotificationsPlugin extends Mock
+    implements AndroidFlutterLocalNotificationsPlugin {}
+
+class _MockIOSFlutterLocalNotificationsPlugin extends Mock
+    implements IOSFlutterLocalNotificationsPlugin {}
+
+class _MockMacFlutterLocalNotificationsPlugin extends Mock
+    implements MacOSFlutterLocalNotificationsPlugin {}
+
+void main() {
+  late _MockFlutterLocalNotificationsPlugin plugin;
+  late NotificationService service;
+
+  setUpAll(() {
+    registerFallbackValue<bool>(false);
+  });
+
+  setUp(() {
+    plugin = _MockFlutterLocalNotificationsPlugin();
+    service = NotificationService(plugin: plugin);
+  });
+
+  test('treats null Android permission result as granted', () async {
+    final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+    when(() => plugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>())
+        .thenReturn(androidPlugin);
+    when(() => androidPlugin.requestNotificationsPermission())
+        .thenAnswer((_) async => null);
+
+    final granted = await service.requestPermission();
+
+    expect(granted, isTrue);
+  });
+
+  test('returns false when every platform denies notifications', () async {
+    final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
+    final iosPlugin = _MockIOSFlutterLocalNotificationsPlugin();
+    final macPlugin = _MockMacFlutterLocalNotificationsPlugin();
+
+    when(() => plugin.resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>())
+        .thenReturn(androidPlugin);
+    when(() => plugin.resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>())
+        .thenReturn(iosPlugin);
+    when(() => plugin.resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin>())
+        .thenReturn(macPlugin);
+
+    when(() => androidPlugin.requestNotificationsPermission())
+        .thenAnswer((_) async => false);
+    when(() => iosPlugin.requestPermissions(
+          alert: any(named: 'alert'),
+          badge: any(named: 'badge'),
+          sound: any(named: 'sound'),
+        )).thenAnswer((_) async => false);
+    when(() => macPlugin.requestPermissions(
+          alert: any(named: 'alert'),
+          badge: any(named: 'badge'),
+          sound: any(named: 'sound'),
+        )).thenAnswer((_) async => false);
+
+    final granted = await service.requestPermission();
+
+    expect(granted, isFalse);
+  });
+}

--- a/test/core/services/notification_service_test.dart
+++ b/test/core/services/notification_service_test.dart
@@ -20,10 +20,6 @@ void main() {
   late _MockFlutterLocalNotificationsPlugin plugin;
   late NotificationService service;
 
-  setUpAll(() {
-    registerFallbackValue<bool>(false);
-  });
-
   setUp(() {
     plugin = _MockFlutterLocalNotificationsPlugin();
     service = NotificationService(plugin: plugin);
@@ -31,11 +27,15 @@ void main() {
 
   test('treats null Android permission result as granted', () async {
     final androidPlugin = _MockAndroidFlutterLocalNotificationsPlugin();
-    when(() => plugin.resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>())
-        .thenReturn(androidPlugin);
-    when(() => androidPlugin.requestNotificationsPermission())
-        .thenAnswer((_) async => null);
+    when(
+      () => plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >(),
+    ).thenReturn(androidPlugin);
+    when(
+      () => androidPlugin.requestNotificationsPermission(),
+    ).thenAnswer((_) async => null);
 
     final granted = await service.requestPermission();
 
@@ -47,28 +47,42 @@ void main() {
     final iosPlugin = _MockIOSFlutterLocalNotificationsPlugin();
     final macPlugin = _MockMacFlutterLocalNotificationsPlugin();
 
-    when(() => plugin.resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>())
-        .thenReturn(androidPlugin);
-    when(() => plugin.resolvePlatformSpecificImplementation<
-            IOSFlutterLocalNotificationsPlugin>())
-        .thenReturn(iosPlugin);
-    when(() => plugin.resolvePlatformSpecificImplementation<
-            MacOSFlutterLocalNotificationsPlugin>())
-        .thenReturn(macPlugin);
+    when(
+      () => plugin
+          .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin
+          >(),
+    ).thenReturn(androidPlugin);
+    when(
+      () => plugin
+          .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin
+          >(),
+    ).thenReturn(iosPlugin);
+    when(
+      () => plugin
+          .resolvePlatformSpecificImplementation<
+            MacOSFlutterLocalNotificationsPlugin
+          >(),
+    ).thenReturn(macPlugin);
 
-    when(() => androidPlugin.requestNotificationsPermission())
-        .thenAnswer((_) async => false);
-    when(() => iosPlugin.requestPermissions(
-          alert: any(named: 'alert'),
-          badge: any(named: 'badge'),
-          sound: any(named: 'sound'),
-        )).thenAnswer((_) async => false);
-    when(() => macPlugin.requestPermissions(
-          alert: any(named: 'alert'),
-          badge: any(named: 'badge'),
-          sound: any(named: 'sound'),
-        )).thenAnswer((_) async => false);
+    when(
+      () => androidPlugin.requestNotificationsPermission(),
+    ).thenAnswer((_) async => false);
+    when(
+      () => iosPlugin.requestPermissions(
+        alert: any(named: 'alert'),
+        badge: any(named: 'badge'),
+        sound: any(named: 'sound'),
+      ),
+    ).thenAnswer((_) async => false);
+    when(
+      () => macPlugin.requestPermissions(
+        alert: any(named: 'alert'),
+        badge: any(named: 'badge'),
+        sound: any(named: 'sound'),
+      ),
+    ).thenAnswer((_) async => false);
 
     final granted = await service.requestPermission();
 

--- a/test/features/onboarding/application/onboarding_controller_test.dart
+++ b/test/features/onboarding/application/onboarding_controller_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:habit_tracker/features/onboarding/application/onboarding_controller.dart';
+import 'package:habit_tracker/features/onboarding/application/onboarding_state.dart';
+import 'package:habit_tracker/features/onboarding/application/starter_habit_template.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit.dart';
+import 'package:habit_tracker/features/settings/application/controllers/notification_settings_controller.dart';
+import 'package:habit_tracker/core/services/notification_service.dart';
+
+class _MockHabitsRepository extends Mock implements HabitsRepository {}
+
+class _MockNotificationService extends Mock implements NotificationService {}
+
+class _MockNotificationSettingsController extends Mock
+    implements NotificationSettingsController {}
+
+void main() {
+  late _MockHabitsRepository habitsRepository;
+  late _MockNotificationService notificationService;
+  late _MockNotificationSettingsController notificationSettings;
+  late SharedPreferences prefs;
+
+  setUpAll(() {
+    registerFallbackValue(
+      Habit(
+        id: 'fallback',
+        name: 'Fallback',
+        emoji: '✨',
+        color: 0xFFFFFFFF,
+        days: const [0, 1, 2, 3, 4, 5, 6],
+        reminderId: 'fallback',
+        reminderTime: '08:00',
+        bestStreak: 0,
+        currentStreak: 0,
+      ),
+    );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    habitsRepository = _MockHabitsRepository();
+    notificationService = _MockNotificationService();
+    notificationSettings = _MockNotificationSettingsController();
+
+    when(() => habitsRepository.saveHabit(any())).thenAnswer((_) async {});
+    when(() => notificationSettings.setEnabled(any())).thenAnswer((_) async {});
+    when(() => notificationService.requestPermission())
+        .thenAnswer((_) async => true);
+  });
+
+  OnboardingController buildController() {
+    return OnboardingController(
+      habitsRepository: habitsRepository,
+      notificationService: notificationService,
+      notificationSettings: notificationSettings,
+      preferences: prefs,
+    );
+  }
+
+  test('limits starter habit selection to three items', () {
+    final controller = buildController();
+
+    controller.toggleHabit(starterHabitTemplates[0], 'Meditate');
+    controller.toggleHabit(starterHabitTemplates[1], 'Walk');
+    controller.toggleHabit(starterHabitTemplates[2], 'Drink water');
+    controller.toggleHabit(starterHabitTemplates[3], 'Journal');
+
+    expect(controller.state.selectedHabits.length, 3);
+    expect(
+      controller.state.selectedHabits.containsKey('journal'),
+      isFalse,
+    );
+  });
+
+  test('persists selected habits and sets onboarding flag', () async {
+    final controller = buildController();
+    controller.toggleHabit(starterHabitTemplates[0], 'Meditate');
+    controller.toggleHabit(starterHabitTemplates[1], 'Walk');
+
+    final result = await controller.completeOnboarding();
+
+    expect(result, isTrue);
+    verify(() => habitsRepository.saveHabit(any())).called(2);
+    expect(
+      prefs.getBool(OnboardingController.hasOnboardedKey),
+      isTrue,
+    );
+  });
+
+  test('updates permission status when enabling reminders', () async {
+    final controller = buildController();
+
+    await controller.enableNotifications();
+
+    expect(
+      controller.state.permissionStatus,
+      NotificationPermissionStatus.granted,
+    );
+    verify(() => notificationSettings.setEnabled(true)).called(1);
+    verify(() => notificationService.requestPermission()).called(1);
+  });
+
+  test('declining reminders disables notifications', () async {
+    final controller = buildController();
+
+    await controller.declineNotifications();
+
+    expect(
+      controller.state.permissionStatus,
+      NotificationPermissionStatus.denied,
+    );
+    verify(() => notificationSettings.setEnabled(false)).called(1);
+  });
+}
+

--- a/test/features/onboarding/application/onboarding_controller_test.dart
+++ b/test/features/onboarding/application/onboarding_controller_test.dart
@@ -130,5 +130,18 @@ void main() {
     );
     verify(() => notificationSettings.setEnabled(false)).called(1);
   });
+
+  test('skip to notifications preselects declined reminders', () async {
+    final controller = buildController();
+
+    await controller.skipToNotifications();
+
+    expect(controller.state.pageIndex, 2);
+    expect(
+      controller.state.permissionStatus,
+      NotificationPermissionStatus.denied,
+    );
+    verify(() => notificationSettings.setEnabled(false)).called(1);
+  });
 }
 

--- a/test/features/onboarding/application/onboarding_controller_test.dart
+++ b/test/features/onboarding/application/onboarding_controller_test.dart
@@ -104,6 +104,21 @@ void main() {
     verify(() => notificationService.requestPermission()).called(1);
   });
 
+  test('handles platform denial when enabling reminders', () async {
+    when(() => notificationService.requestPermission())
+        .thenAnswer((_) async => false);
+    final controller = buildController();
+
+    await controller.enableNotifications();
+
+    expect(
+      controller.state.permissionStatus,
+      NotificationPermissionStatus.denied,
+    );
+    verify(() => notificationSettings.setEnabled(false)).called(1);
+    verify(() => notificationService.requestPermission()).called(1);
+  });
+
   test('declining reminders disables notifications', () async {
     final controller = buildController();
 

--- a/test/features/onboarding/presentation/onboarding_screen_test.dart
+++ b/test/features/onboarding/presentation/onboarding_screen_test.dart
@@ -1,0 +1,259 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
+import 'package:habit_tracker/features/habits/domain/entities/habit.dart';
+import 'package:habit_tracker/features/onboarding/application/onboarding_controller.dart';
+import 'package:habit_tracker/features/onboarding/presentation/screens/onboarding_screen.dart';
+import 'package:habit_tracker/features/settings/application/controllers/notification_settings_controller.dart';
+import 'package:habit_tracker/features/settings/application/providers/notification_settings_provider.dart';
+import 'package:habit_tracker/l10n/app_localizations.dart';
+import 'package:habit_tracker/l10n/app_localizations_en.dart';
+import 'package:habit_tracker/core/services/notification_service.dart';
+
+class _MockHabitsRepository extends Mock implements HabitsRepository {}
+
+class _MockNotificationService extends Mock implements NotificationService {}
+
+class _TestNotificationSettingsController
+    extends NotificationSettingsController {
+  _TestNotificationSettingsController({required SharedPreferences prefs})
+    : super(preferences: prefs);
+  int setEnabledCallCount = 0;
+  bool? lastEnabledValue;
+
+  @override
+  Future<void> setEnabled(bool value) {
+    setEnabledCallCount += 1;
+    lastEnabledValue = value;
+    return super.setEnabled(value);
+  }
+}
+
+Future<void> _pumpOnboarding(
+  WidgetTester tester, {
+  required GoRouter router,
+  required HabitsRepository habitsRepository,
+  required NotificationService notificationService,
+  required NotificationSettingsController notificationSettings,
+  required SharedPreferences prefs,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        habitsRepositoryProvider.overrideWithValue(habitsRepository),
+        notificationServiceProvider.overrideWithValue(notificationService),
+        notificationSettingsProvider.overrideWith((ref) {
+          return notificationSettings;
+        }),
+        onboardingControllerProvider.overrideWith((ref) {
+          final controller = OnboardingController(
+            habitsRepository: habitsRepository,
+            notificationService: notificationService,
+            notificationSettings: notificationSettings,
+            preferences: prefs,
+          );
+          return controller;
+        }),
+      ],
+      child: MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockHabitsRepository habitsRepository;
+  late _MockNotificationService notificationService;
+  late _TestNotificationSettingsController notificationSettings;
+  late SharedPreferences prefs;
+  final l10n = AppLocalizationsEn();
+
+  setUpAll(() {
+    registerFallbackValue(
+      Habit(
+        id: 'fallback',
+        name: 'Fallback',
+        emoji: '✨',
+        color: 0xFFFFFFFF,
+        days: const [0, 1, 2, 3, 4, 5, 6],
+        reminderId: 'fallback',
+        reminderTime: '08:00',
+        bestStreak: 0,
+        currentStreak: 0,
+      ),
+    );
+  });
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    habitsRepository = _MockHabitsRepository();
+    notificationService = _MockNotificationService();
+    notificationSettings = _TestNotificationSettingsController(prefs: prefs);
+
+    when(() => habitsRepository.saveHabit(any())).thenAnswer((_) async {});
+  });
+
+  testWidgets('completes onboarding when notifications are granted', (
+    tester,
+  ) async {
+    final permissionCompleter = Completer<bool>();
+    when(
+      () => notificationService.requestPermission(),
+    ).thenAnswer((_) => permissionCompleter.future);
+
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          name: 'onboarding',
+          builder: (context, state) => const OnboardingScreen(),
+        ),
+        GoRoute(
+          path: '/home',
+          name: 'home',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('Home Screen'))),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await _pumpOnboarding(
+      tester,
+      router: router,
+      habitsRepository: habitsRepository,
+      notificationService: notificationService,
+      notificationSettings: notificationSettings,
+      prefs: prefs,
+    );
+
+    expect(find.text(l10n.onboardingTagline), findsOneWidget);
+
+    await tester.tap(find.text(l10n.onboardingGetStarted));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.onboardingHabitsTitle), findsOneWidget);
+
+    await tester.tap(find.text(l10n.onboardingHabitMeditate));
+    await tester.tap(find.text(l10n.onboardingHabitWalk));
+    await tester.pump();
+
+    final continueFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingContinue,
+    );
+    expect(tester.widget<ElevatedButton>(continueFinder).onPressed, isNotNull);
+
+    await tester.tap(continueFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.onboardingNotificationsTitle), findsOneWidget);
+
+    final enableFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingEnableReminders,
+    );
+    await tester.tap(enableFinder);
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+    permissionCompleter.complete(true);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.onboardingNotificationsGranted), findsOneWidget);
+
+    final finishFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingFinishCta,
+    );
+    await tester.tap(finishFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home Screen'), findsOneWidget);
+    expect(prefs.getBool(OnboardingController.hasOnboardedKey), isTrue);
+    expect(notificationSettings.lastEnabledValue, isTrue);
+    verify(() => notificationService.requestPermission()).called(1);
+    verify(() => habitsRepository.saveHabit(any())).called(2);
+  });
+
+  testWidgets('later button declines reminders without requesting permission', (
+    tester,
+  ) async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          name: 'onboarding',
+          builder: (context, state) => const OnboardingScreen(),
+        ),
+        GoRoute(
+          path: '/home',
+          name: 'home',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('Home Screen'))),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await _pumpOnboarding(
+      tester,
+      router: router,
+      habitsRepository: habitsRepository,
+      notificationService: notificationService,
+      notificationSettings: notificationSettings,
+      prefs: prefs,
+    );
+
+    await tester.tap(find.text(l10n.onboardingGetStarted));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(l10n.onboardingHabitMeditate));
+    await tester.pump();
+
+    final continueFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingContinue,
+    );
+    await tester.tap(continueFinder);
+    await tester.pumpAndSettle();
+
+    final laterFinder = find.widgetWithText(
+      TextButton,
+      l10n.onboardingMaybeLater,
+    );
+    await tester.tap(laterFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.onboardingNotificationsDenied), findsOneWidget);
+
+    final finishFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingFinishCta,
+    );
+    expect(tester.widget<ElevatedButton>(finishFinder).onPressed, isNotNull);
+
+    await tester.tap(finishFinder);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home Screen'), findsOneWidget);
+    expect(notificationSettings.lastEnabledValue, isFalse);
+    verifyNever(() => notificationService.requestPermission());
+    verify(() => habitsRepository.saveHabit(any())).called(1);
+  });
+}

--- a/test/features/onboarding/presentation/onboarding_screen_test.dart
+++ b/test/features/onboarding/presentation/onboarding_screen_test.dart
@@ -256,4 +256,45 @@ void main() {
     verifyNever(() => notificationService.requestPermission());
     verify(() => habitsRepository.saveHabit(any())).called(1);
   });
+
+  testWidgets('skip jumps to reminders step with finish enabled', (tester) async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          name: 'onboarding',
+          builder: (context, state) => const OnboardingScreen(),
+        ),
+        GoRoute(
+          path: '/home',
+          name: 'home',
+          builder: (context, state) =>
+              const Scaffold(body: Center(child: Text('Home Screen'))),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await _pumpOnboarding(
+      tester,
+      router: router,
+      habitsRepository: habitsRepository,
+      notificationService: notificationService,
+      notificationSettings: notificationSettings,
+      prefs: prefs,
+    );
+
+    await tester.tap(find.text(l10n.onboardingSkip));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.onboardingNotificationsTitle), findsOneWidget);
+    expect(notificationSettings.setEnabledCallCount, 1);
+    expect(notificationSettings.lastEnabledValue, isFalse);
+
+    final finishFinder = find.widgetWithText(
+      ElevatedButton,
+      l10n.onboardingFinishCta,
+    );
+    expect(tester.widget<ElevatedButton>(finishFinder).onPressed, isNotNull);
+  });
 }


### PR DESCRIPTION
## Summary
- add an onboarding page view with welcome, starter habit selection, and reminder permission steps
- create an onboarding controller to persist starter habits, request notification permissions, and mark completion
- update routing, localization, and tests to surface the onboarding flow once before landing on the dashboard

## Testing
- fvm flutter analyze
- fvm flutter test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68e2e235a26c8325a5516e49c81ef5d7