### PR TITLE
feat(history): add history screen and analytics coverage

### DIFF
--- a/lib/core/utils/date_helpers.dart
+++ b/lib/core/utils/date_helpers.dart
@@ -26,6 +26,36 @@ class DateHelpers {
         first.day == second.day;
   }
 
+  /// Returns `true` when [date] falls between [start] and [end] (inclusive).
+  static bool isWithinRange(DateTime date, DateTime start, DateTime end) {
+    final normalized = startOfDay(date);
+    final normalizedStart = startOfDay(start);
+    final normalizedEnd = startOfDay(end);
+    if (normalizedStart.isAfter(normalizedEnd)) {
+      throw ArgumentError('start must be on or before end');
+    }
+    return !normalized.isBefore(normalizedStart) &&
+        !normalized.isAfter(normalizedEnd);
+  }
+
+  /// Generates an ordered list of days between [start] and [end] (inclusive).
+  static List<DateTime> daysInRange(DateTime start, DateTime end) {
+    var normalizedStart = startOfDay(start);
+    var normalizedEnd = startOfDay(end);
+    if (normalizedStart.isAfter(normalizedEnd)) {
+      final temp = normalizedStart;
+      normalizedStart = normalizedEnd;
+      normalizedEnd = temp;
+    }
+    final days = <DateTime>[];
+    var cursor = normalizedStart;
+    while (!cursor.isAfter(normalizedEnd)) {
+      days.add(cursor);
+      cursor = cursor.add(const Duration(days: 1));
+    }
+    return List<DateTime>.unmodifiable(days);
+  }
+
   /// Maps the provided [date] to the app's weekday index where Monday = 0 and
   /// Sunday = 6.
   static int weekdayIndex(DateTime date) {

--- a/lib/features/habits/application/habit_form_controller.dart
+++ b/lib/features/habits/application/habit_form_controller.dart
@@ -8,6 +8,7 @@ import 'package:uuid/uuid.dart';
 
 import '../../../core/services/analytics_service.dart';
 import '../../../core/services/notification_service.dart';
+import '../../../core/utils/date_helpers.dart';
 import '../data/repositories/habit_entries_repository.dart';
 import '../data/repositories/habits_repository.dart';
 import '../domain/domain.dart';
@@ -187,8 +188,9 @@ class HabitFormController extends Notifier<HabitFormState> {
     _uuid = ref.read(habitFormUuidProvider);
 
     final mode = _habitId == null ? HabitFormMode.create : HabitFormMode.edit;
-    final initialState = HabitFormState.initial(mode: mode)
-        .copyWith(habitId: _habitId);
+    final initialState = HabitFormState.initial(
+      mode: mode,
+    ).copyWith(habitId: _habitId);
     _baseline = _snapshotFromState(initialState);
 
     if (_habitId == null) {
@@ -361,10 +363,7 @@ class HabitFormController extends Notifier<HabitFormState> {
         isNew: previousMode == HabitFormMode.create,
       );
     } catch (error) {
-      await _analytics.logSaveFail(
-        mode: previousMode,
-        errorCode: 'exception',
-      );
+      await _analytics.logSaveFail(mode: previousMode, errorCode: 'exception');
       _emit(state.copyWith(isSaving: false, errorMessage: error.toString()));
       return HabitFormSaveResult.failure(message: error.toString());
     }
@@ -442,6 +441,7 @@ class HabitFormController extends Notifier<HabitFormState> {
       reminderTime: state.reminderEnabled ? state.reminderTime : '',
       bestStreak: existing?.bestStreak ?? 0,
       currentStreak: existing?.currentStreak ?? 0,
+      createdAt: existing?.createdAt ?? DateHelpers.startOfDay(_clock()),
       lastChecked: existing?.lastChecked,
     );
 

--- a/lib/features/habits/application/history_analytics.dart
+++ b/lib/features/habits/application/history_analytics.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/analytics_service.dart';
+import '../domain/domain.dart';
+
+@immutable
+class HistoryAnalytics {
+  const HistoryAnalytics();
+
+  Future<void> logView({required int dateRangeDays, required int totalHabits}) {
+    return AnalyticsService.logEvent(
+      'history_view',
+      parameters: {
+        'date_range_days': dateRangeDays,
+        'total_habits': totalHabits,
+      },
+    );
+  }
+
+  Future<void> logEmptyState({required int totalHabits}) {
+    return AnalyticsService.logEvent(
+      'history_empty_state_shown',
+      parameters: {'total_habits': totalHabits},
+    );
+  }
+
+  Future<void> logDaySelect({
+    required DateTime date,
+    required double completionRate,
+    int? streakOnDate,
+  }) {
+    return AnalyticsService.logEvent(
+      'history_day_select',
+      parameters: {
+        'date': date.toIso8601String().substring(0, 10),
+        'completion_rate': completionRate,
+        if (streakOnDate != null) 'streak_on_date': streakOnDate,
+      },
+    );
+  }
+
+  Future<void> logScrollRange({
+    required int daysLoaded,
+    required String direction,
+  }) {
+    return AnalyticsService.logEvent(
+      'history_scroll_range',
+      parameters: {'days_loaded': daysLoaded, 'direction': direction},
+    );
+  }
+
+  Future<void> logFilterToggle(Habit habit) {
+    return AnalyticsService.logEvent(
+      'history_filter_toggle',
+      parameters: {
+        'habit_hash': _hashHabitId(habit.id),
+        'emoji': habit.emoji,
+        'color_hex': _colorHex(habit.color),
+      },
+    );
+  }
+
+  Future<void> logStreakSummary({
+    required int bestStreak,
+    required int currentStreak,
+  }) {
+    return AnalyticsService.logEvent(
+      'history_streak_summary_shown',
+      parameters: {'best_streak': bestStreak, 'current_streak': currentStreak},
+    );
+  }
+
+  static String _hashHabitId(String id) {
+    final digest = sha1.convert(utf8.encode(id));
+    return digest.toString().substring(0, 12);
+  }
+
+  static String _colorHex(int color) {
+    return color.toRadixString(16).padLeft(8, '0');
+  }
+}
+
+final historyAnalyticsProvider = Provider<HistoryAnalytics>((ref) {
+  return const HistoryAnalytics();
+});

--- a/lib/features/habits/application/history_controller.dart
+++ b/lib/features/habits/application/history_controller.dart
@@ -1,0 +1,410 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/utils/date_helpers.dart';
+import '../data/repositories/habit_entries_repository.dart';
+import '../data/repositories/habits_repository.dart';
+import '../domain/domain.dart';
+import '../domain/usecases/get_habit_history.dart';
+import 'history_analytics.dart';
+import 'history_state.dart';
+
+class HistoryController extends Notifier<HistoryState> {
+  HistoryController({
+    GetHabitHistory? getHabitHistory,
+    HistoryAnalytics? analytics,
+    HabitsRepository? habitsRepository,
+    HabitEntriesRepository? entriesRepository,
+    DateTime Function()? clock,
+    Timer Function(Duration, void Function())? timerFactory,
+  }) : _getHabitHistoryOverride = getHabitHistory,
+       _analyticsOverride = analytics,
+       _habitsRepositoryOverride = habitsRepository,
+       _entriesRepositoryOverride = entriesRepository,
+       _clockOverride = clock,
+       _timerFactoryOverride = timerFactory;
+
+  static const int _rangeDays = 30;
+
+  final GetHabitHistory? _getHabitHistoryOverride;
+  final HistoryAnalytics? _analyticsOverride;
+  final HabitsRepository? _habitsRepositoryOverride;
+  final HabitEntriesRepository? _entriesRepositoryOverride;
+  final DateTime Function()? _clockOverride;
+  final Timer Function(Duration, void Function())? _timerFactoryOverride;
+
+  late final GetHabitHistory _getHabitHistory;
+  late final HistoryAnalytics _analytics;
+  late final HabitsRepository _habitsRepository;
+  late final HabitEntriesRepository _entriesRepository;
+  late DateTime Function() _clock;
+  late Timer Function(Duration, void Function()) _timerFactory;
+
+  Timer? _midnightTimer;
+  StreamSubscription<List<Habit>>? _habitsSubscription;
+  StreamSubscription<List<HabitEntry>>? _entriesSubscription;
+  bool _viewLogged = false;
+  bool _emptyLogged = false;
+  bool _streakLogged = false;
+  final Set<HistoryScrollDirection> _loggedScrollDirections = {};
+
+  @override
+  HistoryState build() {
+    _getHabitHistory =
+        _getHabitHistoryOverride ?? ref.read(getHabitHistoryProvider);
+    _analytics = _analyticsOverride ?? ref.read(historyAnalyticsProvider);
+    _habitsRepository =
+        _habitsRepositoryOverride ?? ref.read(habitsRepositoryProvider);
+    _entriesRepository =
+        _entriesRepositoryOverride ?? ref.read(habitEntriesRepositoryProvider);
+    _clock = _clockOverride ?? ref.read(historyControllerClockProvider);
+    _timerFactory =
+        _timerFactoryOverride ?? ref.read(historyControllerTimerProvider);
+
+    final today = DateHelpers.startOfDay(_clock());
+    final initialState = HistoryState.initial(today, rangeDays: _rangeDays);
+
+    Future<void>.microtask(() {
+      if (!ref.mounted) return;
+      _initialize();
+    });
+
+    ref.onDispose(() {
+      _midnightTimer?.cancel();
+      unawaited(_habitsSubscription?.cancel());
+      unawaited(_entriesSubscription?.cancel());
+    });
+
+    return initialState;
+  }
+
+  Future<void> _initialize() async {
+    _scheduleMidnightRefresh();
+    await _loadRange(showLoading: true);
+    _subscribeToHabits();
+    _subscribeToEntries();
+  }
+
+  Future<void> refresh() => _loadRange(showLoading: true);
+
+  Future<void> selectDate(DateTime date) async {
+    final normalized = DateHelpers.startOfDay(date);
+    final clamped = _clampToRange(normalized);
+    if (state.selectedDate == clamped) {
+      return;
+    }
+    state = state.copyWith(selectedDate: clamped, clearError: true);
+    final completionRate = state.dayFor(clamped)?.completionRate ?? 0;
+    final streak = _computeStreakOnDate(clamped);
+    await _analytics.logDaySelect(
+      date: clamped,
+      completionRate: completionRate,
+      streakOnDate: streak > 0 ? streak : null,
+    );
+  }
+
+  Future<void> applyHabitFilter(String? habitId) async {
+    if (state.filterHabitId == habitId) {
+      return;
+    }
+    final previousFilter = state.filterHabitId;
+    state = state.copyWith(
+      filterHabitId: habitId,
+      selectedDate: state.rangeEnd,
+      isLoading: true,
+    );
+    _loggedScrollDirections.clear();
+    await _loadRange(showLoading: false);
+    if (habitId != null && habitId != previousFilter) {
+      final habit = _findHabit(habitId);
+      if (habit != null) {
+        await _analytics.logFilterToggle(habit);
+      }
+    }
+    _subscribeToEntries();
+  }
+
+  Future<void> reportScroll(HistoryScrollDirection direction) {
+    if (_loggedScrollDirections.contains(direction)) {
+      return Future<void>.value();
+    }
+    _loggedScrollDirections.add(direction);
+    final label = direction == HistoryScrollDirection.backward
+        ? 'backward'
+        : 'forward';
+    return _analytics.logScrollRange(
+      daysLoaded: state.days.length,
+      direction: label,
+    );
+  }
+
+  Future<void> _loadRange({required bool showLoading}) async {
+    if (showLoading) {
+      state = state.copyWith(isLoading: true, clearError: true);
+    }
+    try {
+      final snapshot = await _getHabitHistory(
+        startDate: state.rangeStart,
+        endDate: state.rangeEnd,
+        habitId: state.filterHabitId,
+      );
+
+      final days = snapshot.days
+          .map(
+            (day) => HistoryDayViewData(
+              date: day.date,
+              habits: day.items
+                  .map(
+                    (item) => HistoryHabitViewData(
+                      habit: item.habit,
+                      date: day.date,
+                      status: _resolveHabitStatus(day.date, item),
+                    ),
+                  )
+                  .toList(growable: false),
+            ),
+          )
+          .toList(growable: false);
+
+      final selected = _resolveSelectedDate(days);
+      final streakSummary = _buildStreakSummary(
+        habits: snapshot.habits,
+        filterHabitId: state.filterHabitId,
+      );
+
+      state = state.copyWith(
+        days: days,
+        habits: snapshot.habits,
+        selectedDate: selected,
+        isLoading: false,
+        clearError: true,
+        streakSummary: streakSummary,
+      );
+
+      _maybeLogView(snapshot);
+      _maybeLogEmptyState(snapshot);
+      _maybeLogStreakSummary(streakSummary);
+    } catch (error) {
+      state = state.copyWith(isLoading: false, errorMessage: error.toString());
+    }
+  }
+
+  void _maybeLogView(HabitHistorySnapshot snapshot) {
+    if (_viewLogged) return;
+    unawaited(
+      _analytics.logView(
+        dateRangeDays: _rangeDays,
+        totalHabits: snapshot.habits.length,
+      ),
+    );
+    _viewLogged = true;
+  }
+
+  void _maybeLogEmptyState(HabitHistorySnapshot snapshot) {
+    if (_emptyLogged || !state.isEmpty) {
+      return;
+    }
+    unawaited(_analytics.logEmptyState(totalHabits: snapshot.habits.length));
+    _emptyLogged = true;
+  }
+
+  void _maybeLogStreakSummary(HistoryStreakSummary summary) {
+    if (_streakLogged || !summary.hasData) {
+      return;
+    }
+    unawaited(
+      _analytics.logStreakSummary(
+        bestStreak: summary.bestStreak,
+        currentStreak: summary.currentStreak,
+      ),
+    );
+    _streakLogged = true;
+  }
+
+  HistoryStreakSummary _buildStreakSummary({
+    required List<Habit> habits,
+    String? filterHabitId,
+  }) {
+    if (habits.isEmpty) {
+      return const HistoryStreakSummary(bestStreak: 0, currentStreak: 0);
+    }
+    if (filterHabitId != null) {
+      final habit = _findHabitIn(habits, filterHabitId);
+      if (habit != null) {
+        return HistoryStreakSummary(
+          bestStreak: habit.bestStreak,
+          currentStreak: habit.currentStreak,
+          bestHabit: habit,
+          currentHabit: habit,
+        );
+      }
+    }
+
+    Habit? bestHabit;
+    Habit? currentHabit;
+    var bestStreak = 0;
+    var currentStreak = 0;
+
+    for (final habit in habits) {
+      if (habit.bestStreak > bestStreak) {
+        bestStreak = habit.bestStreak;
+        bestHabit = habit;
+      }
+      if (habit.currentStreak > currentStreak) {
+        currentStreak = habit.currentStreak;
+        currentHabit = habit;
+      }
+    }
+
+    return HistoryStreakSummary(
+      bestStreak: bestStreak,
+      currentStreak: currentStreak,
+      bestHabit: bestHabit,
+      currentHabit: currentHabit,
+    );
+  }
+
+  DateTime _resolveSelectedDate(List<HistoryDayViewData> days) {
+    if (days.isEmpty) {
+      return state.rangeEnd;
+    }
+    final desired = DateHelpers.startOfDay(state.selectedDate);
+    final available = {for (final day in days) day.date: day};
+    if (available.containsKey(desired)) {
+      return desired;
+    }
+    return days.last.date;
+  }
+
+  int _computeStreakOnDate(DateTime date) {
+    if (state.days.isEmpty) return 0;
+    final target = DateHelpers.startOfDay(date);
+    final relevantDays =
+        state.days.where((day) => !day.date.isAfter(target)).toList()
+          ..sort((a, b) => b.date.compareTo(a.date));
+    var streak = 0;
+    for (final day in relevantDays) {
+      if (day.totalCount == 0) {
+        continue;
+      }
+      final completed = state.filterHabitId == null
+          ? (day.totalCount > 0 && day.completedCount == day.totalCount)
+          : day.habits.any(
+              (habit) =>
+                  habit.habit.id == state.filterHabitId && habit.isCompleted,
+            );
+      if (completed) {
+        streak += 1;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  HistoryHabitStatus _resolveHabitStatus(DateTime day, HabitHistoryItem item) {
+    if (item.isCompleted) {
+      return HistoryHabitStatus.completed;
+    }
+    final today = DateHelpers.startOfDay(_clock());
+    final target = DateHelpers.startOfDay(day);
+    if (target.isBefore(today)) {
+      return HistoryHabitStatus.missed;
+    }
+    return HistoryHabitStatus.pending;
+  }
+
+  Habit? _findHabit(String habitId) {
+    for (final habit in state.habits) {
+      if (habit.id == habitId) {
+        return habit;
+      }
+    }
+    return null;
+  }
+
+  Habit? _findHabitIn(List<Habit> habits, String habitId) {
+    for (final habit in habits) {
+      if (habit.id == habitId) {
+        return habit;
+      }
+    }
+    return null;
+  }
+
+  void _subscribeToHabits() {
+    _habitsSubscription?.cancel();
+    _habitsSubscription = _habitsRepository.watchHabits().listen(
+      (_) => unawaited(_loadRange(showLoading: false)),
+      onError: (error, _) {
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: error.toString(),
+        );
+      },
+    );
+  }
+
+  void _subscribeToEntries() {
+    _entriesSubscription?.cancel();
+    _entriesSubscription = _entriesRepository
+        .watchEntriesInRange(
+          state.rangeStart,
+          state.rangeEnd,
+          habitId: state.filterHabitId,
+        )
+        .listen(
+          (_) => unawaited(_loadRange(showLoading: false)),
+          onError: (error, _) {
+            state = state.copyWith(
+              isLoading: false,
+              errorMessage: error.toString(),
+            );
+          },
+        );
+  }
+
+  void _scheduleMidnightRefresh() {
+    _midnightTimer?.cancel();
+    final delay = DateHelpers.timeUntilNextDay(_clock());
+    _midnightTimer = _timerFactory(delay, _handleMidnightTick);
+  }
+
+  void _handleMidnightTick() {
+    _midnightTimer = null;
+    final today = DateHelpers.startOfDay(_clock());
+    final start = today.subtract(const Duration(days: _rangeDays - 1));
+    state = state.copyWith(rangeStart: start, rangeEnd: today);
+    _loggedScrollDirections.clear();
+    _scheduleMidnightRefresh();
+    _subscribeToEntries();
+    unawaited(_loadRange(showLoading: true));
+  }
+
+  DateTime _clampToRange(DateTime date) {
+    if (date.isBefore(state.rangeStart)) {
+      return state.rangeStart;
+    }
+    if (date.isAfter(state.rangeEnd)) {
+      return state.rangeEnd;
+    }
+    return date;
+  }
+}
+
+enum HistoryScrollDirection { forward, backward }
+
+final historyControllerClockProvider = Provider<DateTime Function()>((ref) {
+  return DateTime.now;
+});
+
+final historyControllerTimerProvider =
+    Provider<Timer Function(Duration, void Function())>((ref) {
+      return (duration, callback) => Timer(duration, callback);
+    });
+
+final historyControllerProvider =
+    NotifierProvider.autoDispose<HistoryController, HistoryState>(
+      HistoryController.new,
+    );

--- a/lib/features/habits/application/history_state.dart
+++ b/lib/features/habits/application/history_state.dart
@@ -1,0 +1,220 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+import '../domain/domain.dart';
+
+const _unset = Object();
+
+enum HistoryHabitStatus { completed, missed, pending }
+
+@immutable
+class HistoryHabitViewData {
+  const HistoryHabitViewData({
+    required this.habit,
+    required this.date,
+    required this.status,
+  });
+
+  final Habit habit;
+  final DateTime date;
+  final HistoryHabitStatus status;
+
+  bool get isCompleted => status == HistoryHabitStatus.completed;
+  bool get isMissed => status == HistoryHabitStatus.missed;
+  bool get isPending => status == HistoryHabitStatus.pending;
+
+  HistoryHabitViewData copyWith({
+    Habit? habit,
+    DateTime? date,
+    HistoryHabitStatus? status,
+  }) {
+    return HistoryHabitViewData(
+      habit: habit ?? this.habit,
+      date: date ?? this.date,
+      status: status ?? this.status,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is HistoryHabitViewData &&
+        other.habit == habit &&
+        other.date == date &&
+        other.status == status;
+  }
+
+  @override
+  int get hashCode => Object.hash(habit, date, status);
+}
+
+@immutable
+class HistoryDayViewData {
+  HistoryDayViewData({
+    required this.date,
+    required List<HistoryHabitViewData> habits,
+  }) : _habits = List<HistoryHabitViewData>.unmodifiable(habits);
+
+  final DateTime date;
+  final List<HistoryHabitViewData> _habits;
+
+  UnmodifiableListView<HistoryHabitViewData> get habits =>
+      UnmodifiableListView(_habits);
+
+  int get totalCount => _habits.length;
+  int get completedCount => _habits.where((habit) => habit.isCompleted).length;
+  double get completionRate =>
+      totalCount == 0 ? 0 : completedCount / totalCount;
+
+  bool get hasHabits => totalCount > 0;
+
+  HistoryDayViewData copyWith({
+    DateTime? date,
+    List<HistoryHabitViewData>? habits,
+  }) {
+    return HistoryDayViewData(
+      date: date ?? this.date,
+      habits: habits ?? _habits,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is HistoryDayViewData &&
+        other.date == date &&
+        listEquals(other._habits, _habits);
+  }
+
+  @override
+  int get hashCode => Object.hash(date, Object.hashAll(_habits));
+}
+
+@immutable
+class HistoryStreakSummary {
+  const HistoryStreakSummary({
+    required this.bestStreak,
+    required this.currentStreak,
+    this.bestHabit,
+    this.currentHabit,
+  });
+
+  final int bestStreak;
+  final int currentStreak;
+  final Habit? bestHabit;
+  final Habit? currentHabit;
+
+  bool get hasData => bestStreak > 0 || currentStreak > 0;
+
+  HistoryStreakSummary copyWith({
+    int? bestStreak,
+    int? currentStreak,
+    Habit? bestHabit,
+    Habit? currentHabit,
+  }) {
+    return HistoryStreakSummary(
+      bestStreak: bestStreak ?? this.bestStreak,
+      currentStreak: currentStreak ?? this.currentStreak,
+      bestHabit: bestHabit ?? this.bestHabit,
+      currentHabit: currentHabit ?? this.currentHabit,
+    );
+  }
+}
+
+@immutable
+class HistoryState {
+  HistoryState({
+    required this.rangeStart,
+    required this.rangeEnd,
+    required this.selectedDate,
+    required List<HistoryDayViewData> days,
+    required List<Habit> habits,
+    this.filterHabitId,
+    this.isLoading = false,
+    this.errorMessage,
+    HistoryStreakSummary? streakSummary,
+  }) : _days = List<HistoryDayViewData>.unmodifiable(days),
+       _habits = List<Habit>.unmodifiable(habits),
+       streakSummary =
+           streakSummary ??
+           const HistoryStreakSummary(bestStreak: 0, currentStreak: 0);
+
+  factory HistoryState.initial(
+    DateTime referenceDate, {
+    required int rangeDays,
+  }) {
+    final end = DateTime(
+      referenceDate.year,
+      referenceDate.month,
+      referenceDate.day,
+    );
+    final start = end.subtract(Duration(days: rangeDays - 1));
+    return HistoryState(
+      rangeStart: start,
+      rangeEnd: end,
+      selectedDate: end,
+      days: const [],
+      habits: const [],
+      isLoading: true,
+    );
+  }
+
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+  final DateTime selectedDate;
+  final String? filterHabitId;
+  final bool isLoading;
+  final String? errorMessage;
+  final HistoryStreakSummary streakSummary;
+  final List<HistoryDayViewData> _days;
+  final List<Habit> _habits;
+
+  UnmodifiableListView<HistoryDayViewData> get days =>
+      UnmodifiableListView(_days);
+  UnmodifiableListView<Habit> get habits => UnmodifiableListView(_habits);
+
+  Map<DateTime, HistoryDayViewData> get dayIndex => {
+    for (final day in _days) day.date: day,
+  };
+
+  Map<DateTime, double> get completionByDate => {
+    for (final day in _days) day.date: day.completionRate,
+  };
+
+  bool get hasError => errorMessage != null;
+
+  bool get hasHabits => _habits.isNotEmpty;
+
+  bool get isEmpty => !isLoading && _days.every((day) => !day.hasHabits);
+
+  HistoryDayViewData? dayFor(DateTime date) => dayIndex[date];
+
+  HistoryState copyWith({
+    DateTime? rangeStart,
+    DateTime? rangeEnd,
+    DateTime? selectedDate,
+    List<HistoryDayViewData>? days,
+    List<Habit>? habits,
+    Object? filterHabitId = _unset,
+    bool? isLoading,
+    String? errorMessage,
+    bool clearError = false,
+    HistoryStreakSummary? streakSummary,
+  }) {
+    final resolvedFilter = filterHabitId == _unset
+        ? this.filterHabitId
+        : filterHabitId as String?;
+    return HistoryState(
+      rangeStart: rangeStart ?? this.rangeStart,
+      rangeEnd: rangeEnd ?? this.rangeEnd,
+      selectedDate: selectedDate ?? this.selectedDate,
+      days: days ?? _days,
+      habits: habits ?? _habits,
+      filterHabitId: resolvedFilter,
+      isLoading: isLoading ?? this.isLoading,
+      errorMessage: clearError ? null : errorMessage ?? this.errorMessage,
+      streakSummary: streakSummary ?? this.streakSummary,
+    );
+  }
+}

--- a/lib/features/habits/application/home_analytics.dart
+++ b/lib/features/habits/application/home_analytics.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/analytics_service.dart';
+import '../domain/domain.dart';
+import 'home_state.dart';
+
+@immutable
+class HomeAnalytics {
+  const HomeAnalytics();
+
+  Future<void> logView({
+    required int totalHabits,
+    required int completedHabits,
+    required bool isEmpty,
+  }) {
+    return AnalyticsService.logEvent(
+      'home_view',
+      parameters: {
+        'total_habits': totalHabits,
+        'completed_habits': completedHabits,
+        'is_empty': isEmpty ? 1 : 0,
+      },
+    );
+  }
+
+  Future<void> logToggle(Habit habit, bool completed) {
+    return AnalyticsService.logEvent(
+      'home_toggle_habit',
+      parameters: {
+        'habit_hash': _hashId(habit.id),
+        'completed': completed ? 1 : 0,
+      },
+    );
+  }
+
+  Future<void> logRefresh(HomeState state) {
+    return AnalyticsService.logEvent(
+      'home_refresh',
+      parameters: {
+        'total_habits': state.habits.length,
+        'completed_habits': state.completedCount,
+      },
+    );
+  }
+
+  Future<void> logAddHabitTap() {
+    return AnalyticsService.logEvent('home_add_habit_tap');
+  }
+
+  Future<void> logAddHabitLimitReached(int totalHabits) {
+    return AnalyticsService.logEvent(
+      'home_add_habit_limit',
+      parameters: {'total_habits': totalHabits},
+    );
+  }
+
+  Future<void> logHabitActionsOpen(Habit habit) {
+    return AnalyticsService.logEvent(
+      'home_habit_actions_open',
+      parameters: {'habit_hash': _hashId(habit.id)},
+    );
+  }
+
+  Future<void> logHabitActionSelected(
+    Habit habit, {
+    required String action,
+  }) {
+    return AnalyticsService.logEvent(
+      'home_habit_action_select',
+      parameters: {
+        'habit_hash': _hashId(habit.id),
+        'action': action,
+      },
+    );
+  }
+
+  String _hashId(String id) {
+    final digest = sha1.convert(utf8.encode(id));
+    return digest.toString().substring(0, 12);
+  }
+}
+
+final homeAnalyticsProvider = Provider<HomeAnalytics>((ref) {
+  return const HomeAnalytics();
+});

--- a/lib/features/habits/application/home_controller.dart
+++ b/lib/features/habits/application/home_controller.dart
@@ -16,11 +16,11 @@ class HomeController extends Notifier<HomeState> {
     ToggleHabitCompletion? toggleHabitCompletion,
     DateTime Function()? clock,
     Timer Function(Duration, void Function())? timerFactory,
-  })  : _habitsRepositoryOverride = habitsRepository,
-        _habitEntriesRepositoryOverride = habitEntriesRepository,
-        _toggleHabitCompletionOverride = toggleHabitCompletion,
-        _clockOverride = clock,
-        _timerFactoryOverride = timerFactory;
+  }) : _habitsRepositoryOverride = habitsRepository,
+       _habitEntriesRepositoryOverride = habitEntriesRepository,
+       _toggleHabitCompletionOverride = toggleHabitCompletion,
+       _clockOverride = clock,
+       _timerFactoryOverride = timerFactory;
 
   final HabitsRepository? _habitsRepositoryOverride;
   final HabitEntriesRepository? _habitEntriesRepositoryOverride;
@@ -45,12 +45,15 @@ class HomeController extends Notifier<HomeState> {
   HomeState build() {
     _habitsRepository =
         _habitsRepositoryOverride ?? ref.read(habitsRepositoryProvider);
-    _habitEntriesRepository = _habitEntriesRepositoryOverride ??
+    _habitEntriesRepository =
+        _habitEntriesRepositoryOverride ??
         ref.read(habitEntriesRepositoryProvider);
     _toggleHabitCompletion =
-        _toggleHabitCompletionOverride ?? ref.read(toggleHabitCompletionProvider);
+        _toggleHabitCompletionOverride ??
+        ref.read(toggleHabitCompletionProvider);
     _clock = _clockOverride ?? ref.read(homeControllerClockProvider);
-    _timerFactory = _timerFactoryOverride ?? ref.read(homeControllerTimerProvider);
+    _timerFactory =
+        _timerFactoryOverride ?? ref.read(homeControllerTimerProvider);
 
     _currentDay = DateHelpers.startOfDay(_clock());
     _latestHabits = const <Habit>[];
@@ -209,7 +212,6 @@ class HomeController extends Notifier<HomeState> {
     unawaited(_loadCurrentDay());
     _scheduleMidnightRefresh();
   }
-
 }
 
 final homeControllerClockProvider = Provider<DateTime Function()>((ref) {

--- a/lib/features/habits/data/models/habit_record.dart
+++ b/lib/features/habits/data/models/habit_record.dart
@@ -16,6 +16,7 @@ class HabitRecord {
     required this.bestStreak,
     required this.currentStreak,
     this.lastChecked,
+    required this.createdAt,
   }) : days = List<int>.unmodifiable(List<int>.from(days));
 
   final String id;
@@ -28,6 +29,7 @@ class HabitRecord {
   final int bestStreak;
   final int currentStreak;
   final DateTime? lastChecked;
+  final DateTime createdAt;
 
   Habit toHabit() {
     return Habit(
@@ -40,6 +42,7 @@ class HabitRecord {
       reminderTime: reminderTime,
       bestStreak: bestStreak,
       currentStreak: currentStreak,
+      createdAt: createdAt,
       lastChecked: lastChecked,
     );
   }
@@ -56,6 +59,7 @@ class HabitRecord {
       bestStreak: habit.bestStreak,
       currentStreak: habit.currentStreak,
       lastChecked: habit.lastChecked,
+      createdAt: habit.createdAt,
     );
   }
 
@@ -72,7 +76,8 @@ class HabitRecord {
         other.reminderTime == reminderTime &&
         other.bestStreak == bestStreak &&
         other.currentStreak == currentStreak &&
-        other.lastChecked == lastChecked;
+        other.lastChecked == lastChecked &&
+        other.createdAt == createdAt;
   }
 
   @override
@@ -87,11 +92,12 @@ class HabitRecord {
     bestStreak,
     currentStreak,
     lastChecked,
+    createdAt,
   );
 
   @override
   String toString() {
-    return 'HabitRecord(id: $id, name: $name, streak: $currentStreak/$bestStreak)';
+    return 'HabitRecord(id: $id, name: $name, streak: $currentStreak/$bestStreak, createdAt: $createdAt)';
   }
 }
 
@@ -117,13 +123,15 @@ class HabitRecordAdapter extends TypeAdapter<HabitRecord> {
       bestStreak: fields[7] as int,
       currentStreak: fields[8] as int,
       lastChecked: fields[9] as DateTime?,
+      createdAt:
+          (fields[10] as DateTime?) ?? DateTime.fromMillisecondsSinceEpoch(0),
     );
   }
 
   @override
   void write(BinaryWriter writer, HabitRecord obj) {
     writer
-      ..writeByte(10)
+      ..writeByte(11)
       ..writeByte(0)
       ..write(obj.id)
       ..writeByte(1)
@@ -143,6 +151,8 @@ class HabitRecordAdapter extends TypeAdapter<HabitRecord> {
       ..writeByte(8)
       ..write(obj.currentStreak)
       ..writeByte(9)
-      ..write(obj.lastChecked);
+      ..write(obj.lastChecked)
+      ..writeByte(10)
+      ..write(obj.createdAt);
   }
 }

--- a/lib/features/habits/data/repositories/habit_entries_repository.dart
+++ b/lib/features/habits/data/repositories/habit_entries_repository.dart
@@ -32,6 +32,23 @@ class HabitEntriesRepository {
         .toList(growable: false);
   }
 
+  Future<List<HabitEntry>> fetchEntriesInRange(
+    DateTime start,
+    DateTime end, {
+    String? habitId,
+  }) async {
+    final normalizedStart = DateHelpers.startOfDay(start);
+    final normalizedEnd = DateHelpers.startOfDay(end);
+    final entries = await fetchEntries(habitId: habitId);
+    return entries
+        .where((entry) {
+          final entryDate = DateHelpers.startOfDay(entry.date);
+          return !entryDate.isBefore(normalizedStart) &&
+              !entryDate.isAfter(normalizedEnd);
+        })
+        .toList(growable: false);
+  }
+
   Future<void> saveEntry(HabitEntry entry) async {
     final box = _database.habitEntriesBox;
     final record = HabitEntryRecord.fromHabitEntry(entry);
@@ -83,6 +100,24 @@ class HabitEntriesRepository {
     return watchEntries().map(
       (entries) => entries
           .where((entry) => DateHelpers.isSameDay(entry.date, normalized))
+          .toList(growable: false),
+    );
+  }
+
+  Stream<List<HabitEntry>> watchEntriesInRange(
+    DateTime start,
+    DateTime end, {
+    String? habitId,
+  }) {
+    final normalizedStart = DateHelpers.startOfDay(start);
+    final normalizedEnd = DateHelpers.startOfDay(end);
+    return watchEntries(habitId: habitId).map(
+      (entries) => entries
+          .where((entry) {
+            final entryDate = DateHelpers.startOfDay(entry.date);
+            return !entryDate.isBefore(normalizedStart) &&
+                !entryDate.isAfter(normalizedEnd);
+          })
           .toList(growable: false),
     );
   }

--- a/lib/features/habits/domain/entities/habit.dart
+++ b/lib/features/habits/domain/entities/habit.dart
@@ -13,12 +13,14 @@ class Habit {
     required this.reminderTime,
     required this.bestStreak,
     required this.currentStreak,
+    DateTime? createdAt,
     this.lastChecked,
   }) : assert(
          color >= 0 && color <= 0xFFFFFFFF,
          'color must be between 0x00000000 and 0xFFFFFFFF',
        ),
-       days = List.unmodifiable(_normalizeDays(days));
+       days = List.unmodifiable(_normalizeDays(days)),
+       createdAt = _normalizeCreationDate(createdAt ?? _defaultCreationDate);
 
   final String id;
   final String name;
@@ -29,7 +31,15 @@ class Habit {
   final String reminderTime;
   final int bestStreak;
   final int currentStreak;
+  final DateTime createdAt;
   final DateTime? lastChecked;
+
+  static final DateTime _defaultCreationDate =
+      DateTime.fromMillisecondsSinceEpoch(0);
+
+  static DateTime get defaultCreationDate => _defaultCreationDate;
+
+  bool get hasExplicitCreationDate => createdAt != _defaultCreationDate;
 
   Habit copyWith({
     String? id,
@@ -41,6 +51,7 @@ class Habit {
     String? reminderTime,
     int? bestStreak,
     int? currentStreak,
+    DateTime? createdAt,
     DateTime? lastChecked,
     bool clearLastChecked = false,
   }) {
@@ -54,6 +65,7 @@ class Habit {
       reminderTime: reminderTime ?? this.reminderTime,
       bestStreak: bestStreak ?? this.bestStreak,
       currentStreak: currentStreak ?? this.currentStreak,
+      createdAt: createdAt ?? this.createdAt,
       lastChecked: clearLastChecked ? null : (lastChecked ?? this.lastChecked),
     );
   }
@@ -69,6 +81,7 @@ class Habit {
       'reminderTime': reminderTime,
       'bestStreak': bestStreak,
       'currentStreak': currentStreak,
+      'createdAt': createdAt.toIso8601String(),
       'lastChecked': lastChecked?.toIso8601String(),
     };
   }
@@ -94,6 +107,7 @@ class Habit {
       ),
       bestStreak: _requireField(bestStreak, 'bestStreak'),
       currentStreak: _requireField(currentStreak, 'currentStreak'),
+      createdAt: _parseDate(map['createdAt']) ?? _defaultCreationDate,
       lastChecked: map['lastChecked'] == null
           ? null
           : DateTime.tryParse(map['lastChecked'] as String),
@@ -107,6 +121,12 @@ class Habit {
     return const <int>[];
   }
 
+  static DateTime? _parseDate(Object? value) {
+    if (value is DateTime) return value;
+    if (value is String) return DateTime.tryParse(value);
+    return null;
+  }
+
   static T _requireField<T>(T? value, String field) {
     if (value == null) {
       throw ArgumentError.notNull(field);
@@ -118,6 +138,10 @@ class Habit {
     final cleaned = days.where((day) => day >= 0 && day <= 6).toSet().toList()
       ..sort();
     return cleaned;
+  }
+
+  static DateTime _normalizeCreationDate(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
   }
 
   List<HabitWeekday> get weekdaySelections => HabitWeekday.fromIndexList(days);
@@ -135,6 +159,7 @@ class Habit {
         other.reminderTime == reminderTime &&
         other.bestStreak == bestStreak &&
         other.currentStreak == currentStreak &&
+        other.createdAt == createdAt &&
         other.lastChecked == lastChecked;
   }
 
@@ -149,10 +174,11 @@ class Habit {
     reminderTime,
     bestStreak,
     currentStreak,
+    createdAt,
     lastChecked,
   );
 
   @override
   String toString() =>
-      'Habit(id: $id, name: $name, streak: $currentStreak/$bestStreak)';
+      'Habit(id: $id, name: $name, streak: $currentStreak/$bestStreak, createdAt: $createdAt)';
 }

--- a/lib/features/habits/domain/usecases/get_habit_history.dart
+++ b/lib/features/habits/domain/usecases/get_habit_history.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/date_helpers.dart';
+import '../../data/repositories/habit_entries_repository.dart';
+import '../../data/repositories/habits_repository.dart';
+import '../domain.dart';
+
+@immutable
+class HabitHistoryItem {
+  const HabitHistoryItem({required this.habit, required this.date, this.entry});
+
+  final Habit habit;
+  final DateTime date;
+  final HabitEntry? entry;
+
+  bool get isCompleted => entry?.done ?? false;
+
+  HabitHistoryItem copyWith({Habit? habit, DateTime? date, HabitEntry? entry}) {
+    return HabitHistoryItem(
+      habit: habit ?? this.habit,
+      date: date ?? this.date,
+      entry: entry ?? this.entry,
+    );
+  }
+}
+
+@immutable
+class HabitHistoryDay {
+  HabitHistoryDay({required this.date, required List<HabitHistoryItem> items})
+    : items = List<HabitHistoryItem>.unmodifiable(items);
+
+  final DateTime date;
+  final List<HabitHistoryItem> items;
+
+  int get totalCount => items.length;
+  int get completedCount => items.where((item) => item.isCompleted).length;
+  double get completionRate =>
+      totalCount == 0 ? 0 : completedCount / totalCount;
+}
+
+@immutable
+class HabitHistorySnapshot {
+  HabitHistorySnapshot({
+    required this.rangeStart,
+    required this.rangeEnd,
+    required List<HabitHistoryDay> days,
+    required List<Habit> habits,
+  }) : days = List<HabitHistoryDay>.unmodifiable(days),
+       habits = List<Habit>.unmodifiable(habits);
+
+  final DateTime rangeStart;
+  final DateTime rangeEnd;
+  final List<HabitHistoryDay> days;
+  final List<Habit> habits;
+
+  int get totalHabits => habits.length;
+}
+
+class GetHabitHistory {
+  GetHabitHistory({
+    required HabitsRepository habitsRepository,
+    required HabitEntriesRepository entriesRepository,
+  }) : _habitsRepository = habitsRepository,
+       _entriesRepository = entriesRepository;
+
+  final HabitsRepository _habitsRepository;
+  final HabitEntriesRepository _entriesRepository;
+
+  Future<HabitHistorySnapshot> call({
+    required DateTime startDate,
+    required DateTime endDate,
+    String? habitId,
+  }) async {
+    final normalizedStart = DateHelpers.startOfDay(startDate);
+    final normalizedEnd = DateHelpers.startOfDay(endDate);
+    final effectiveStart = normalizedStart.isBefore(normalizedEnd)
+        ? normalizedStart
+        : normalizedEnd;
+    final effectiveEnd = normalizedStart.isBefore(normalizedEnd)
+        ? normalizedEnd
+        : normalizedStart;
+
+    final habits = await _habitsRepository.fetchHabits();
+    final habitMap = {for (final habit in habits) habit.id: habit};
+    final selectedHabit = habitId != null ? habitMap[habitId] : null;
+    final relevantHabits = habitId != null
+        ? <Habit>[if (selectedHabit != null) selectedHabit]
+        : habits;
+
+    final entries = await _entriesRepository.fetchEntriesInRange(
+      effectiveStart,
+      effectiveEnd,
+      habitId: habitId,
+    );
+
+    final entriesByHabit = <String, Map<DateTime, HabitEntry>>{};
+    for (final entry in entries) {
+      final entryDate = DateHelpers.startOfDay(entry.date);
+      final habitEntries = entriesByHabit.putIfAbsent(entry.habitId, () => {});
+      habitEntries[entryDate] = entry;
+    }
+
+    final creationDates = <String, DateTime>{
+      for (final habit in habits)
+        habit.id: _resolveCreationDate(
+          habit,
+          entriesByHabit[habit.id]?.keys,
+          effectiveStart,
+        ),
+    };
+
+    final days = <HabitHistoryDay>[];
+    for (final date in DateHelpers.daysInRange(effectiveStart, effectiveEnd)) {
+      final dayHabits = habitId == null
+          ? _filterHabitsForDate(habits, date, creationDates)
+          : relevantHabits
+                .where(
+                  (habit) => !_createdAfterDate(habit.id, date, creationDates),
+                )
+                .toList(growable: false);
+      final items = <HabitHistoryItem>[];
+      for (final habit in dayHabits) {
+        if (_createdAfterDate(habit.id, date, creationDates)) {
+          continue;
+        }
+        final entry = entriesByHabit[habit.id]?[DateHelpers.startOfDay(date)];
+        items.add(HabitHistoryItem(habit: habit, date: date, entry: entry));
+      }
+      days.add(HabitHistoryDay(date: date, items: items));
+    }
+
+    return HabitHistorySnapshot(
+      rangeStart: effectiveStart,
+      rangeEnd: effectiveEnd,
+      days: days,
+      habits: habits,
+    );
+  }
+
+  List<Habit> _filterHabitsForDate(
+    List<Habit> habits,
+    DateTime date,
+    Map<String, DateTime> creationDates,
+  ) {
+    if (habits.isEmpty) {
+      return const <Habit>[];
+    }
+    final weekday = DateHelpers.weekdayIndex(date);
+    final normalizedDate = DateHelpers.startOfDay(date);
+    final filtered = habits
+        .where(
+          (habit) =>
+              (habit.days.isEmpty || habit.days.contains(weekday)) &&
+              !_createdAfterDate(habit.id, normalizedDate, creationDates),
+        )
+        .toList(growable: false);
+    if (filtered.length <= HabitsRepository.maxHabitsPerDay) {
+      return filtered;
+    }
+    return filtered
+        .take(HabitsRepository.maxHabitsPerDay)
+        .toList(growable: false);
+  }
+
+  DateTime _resolveCreationDate(
+    Habit habit,
+    Iterable<DateTime>? entryDates,
+    DateTime fallback,
+  ) {
+    final normalizedCreation = DateHelpers.startOfDay(habit.createdAt);
+    var effective = normalizedCreation;
+
+    final normalizedEntries = entryDates == null
+        ? const <DateTime>[]
+        : entryDates.map(DateHelpers.startOfDay);
+    final earliestEntry = normalizedEntries.isEmpty
+        ? null
+        : normalizedEntries.reduce(
+            (previous, element) =>
+                element.isBefore(previous) ? element : previous,
+          );
+
+    if (!habit.hasExplicitCreationDate && earliestEntry != null) {
+      effective = earliestEntry;
+    }
+
+    if (!habit.hasExplicitCreationDate && earliestEntry == null) {
+      effective = fallback;
+    }
+
+    if (earliestEntry != null && earliestEntry.isBefore(effective)) {
+      effective = earliestEntry;
+    }
+
+    return effective;
+  }
+
+  bool _createdAfterDate(
+    String habitId,
+    DateTime date,
+    Map<String, DateTime> creationDates,
+  ) {
+    final created = creationDates[habitId];
+    if (created == null) {
+      return false;
+    }
+    final target = DateHelpers.startOfDay(date);
+    return created.isAfter(target);
+  }
+}
+
+final getHabitHistoryProvider = Provider<GetHabitHistory>((ref) {
+  final habitsRepository = ref.watch(habitsRepositoryProvider);
+  final entriesRepository = ref.watch(habitEntriesRepositoryProvider);
+  return GetHabitHistory(
+    habitsRepository: habitsRepository,
+    entriesRepository: entriesRepository,
+  );
+});

--- a/lib/features/habits/presentation/screens/history_screen.dart
+++ b/lib/features/habits/presentation/screens/history_screen.dart
@@ -1,25 +1,246 @@
 import 'package:flutter/material.dart';
-import 'package:habit_tracker/core/localization/l10n_extensions.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class HistoryScreen extends StatelessWidget {
+import '../../../../core/localization/l10n_extensions.dart';
+import '../../../../core/utils/date_helpers.dart';
+import '../../application/history_controller.dart';
+import '../../application/history_state.dart';
+import '../widgets/habit_day_list.dart';
+import '../widgets/history_empty_state.dart';
+import '../widgets/week_strip.dart';
+
+class HistoryScreen extends ConsumerWidget {
   const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<HistoryState>(historyControllerProvider, (previous, next) {
+      if (next.errorMessage != null &&
+          next.errorMessage != previous?.errorMessage) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(SnackBar(content: Text(next.errorMessage!)));
+      }
+    });
+
+    final state = ref.watch(historyControllerProvider);
+    final controller = ref.read(historyControllerProvider.notifier);
+    final l10n = context.l10n;
+
+    final selectedDay = state.dayFor(state.selectedDate);
+    final accentColor = _resolveAccentColor(state);
+
+    if (state.isLoading && state.days.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: Text(l10n.historyTitle)),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (state.isEmpty) {
+      return Scaffold(
+        appBar: AppBar(title: Text(l10n.historyTitle)),
+        body: const HistoryEmptyState(),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(l10n.historyTitle),
+        bottom: state.isLoading
+            ? const PreferredSize(
+                preferredSize: Size.fromHeight(2),
+                child: LinearProgressIndicator(minHeight: 2),
+              )
+            : null,
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.historyStreakHeading,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _HistoryStreakCard(summary: state.streakSummary),
+                if (state.habits.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  _HistoryFilter(
+                    state: state,
+                    onChanged: (value) => controller.applyHabitFilter(value),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          WeekStrip(
+            days: state.days,
+            selectedDate: state.selectedDate,
+            accentColor: accentColor,
+            onSelect: (date) {
+              HapticFeedback.lightImpact();
+              controller.selectDate(date);
+              final difference = state.rangeEnd
+                  .difference(DateHelpers.startOfDay(date))
+                  .inDays;
+              if (difference >= 7) {
+                controller.reportScroll(HistoryScrollDirection.backward);
+              }
+            },
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: HabitDayList(
+              date: state.selectedDate,
+              day: selectedDay,
+              isLoading: state.isLoading,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color? _resolveAccentColor(HistoryState state) {
+    final filterId = state.filterHabitId;
+    if (filterId == null) {
+      return null;
+    }
+    for (final habit in state.habits) {
+      if (habit.id == filterId) {
+        return Color(habit.color);
+      }
+    }
+    return null;
+  }
+}
+
+class _HistoryStreakCard extends StatelessWidget {
+  const _HistoryStreakCard({required this.summary});
+
+  final HistoryStreakSummary summary;
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
 
-    return Scaffold(
-      appBar: AppBar(title: Text(l10n.historyTitle)),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(
-            l10n.historyPlaceholder,
-            style: Theme.of(context).textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-          ),
+    return Card(
+      elevation: 0,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            _StreakMetric(
+              label: l10n.historyStreakBest,
+              value: summary.bestStreak,
+              habitName: summary.bestHabit?.name,
+            ),
+            const SizedBox(width: 24),
+            _StreakMetric(
+              label: l10n.historyStreakCurrent,
+              value: summary.currentStreak,
+              habitName: summary.currentHabit?.name,
+            ),
+          ],
         ),
       ),
+    );
+  }
+}
+
+class _StreakMetric extends StatelessWidget {
+  const _StreakMetric({
+    required this.label,
+    required this.value,
+    required this.habitName,
+  });
+
+  final String label;
+  final int value;
+  final String? habitName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subtitle = habitName ?? '';
+
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value.toString(),
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          if (subtitle.isNotEmpty) ...[
+            const SizedBox(height: 4),
+            Text(
+              subtitle,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _HistoryFilter extends StatelessWidget {
+  const _HistoryFilter({required this.state, required this.onChanged});
+
+  final HistoryState state;
+  final ValueChanged<String?> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final options = <DropdownMenuItem<String?>>[
+      DropdownMenuItem<String?>(
+        value: null,
+        child: Text(l10n.historyFilterAll),
+      ),
+      ...state.habits.map(
+        (habit) => DropdownMenuItem<String?>(
+          value: habit.id,
+          child: Text('${habit.emoji} ${habit.name}'),
+        ),
+      ),
+    ];
+
+    return DropdownButtonFormField<String?>(
+      key: ValueKey(state.filterHabitId ?? 'all'),
+      initialValue: state.filterHabitId,
+      decoration: InputDecoration(
+        labelText: l10n.historyFilterLabel,
+        border: const OutlineInputBorder(),
+        isDense: true,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 12,
+          vertical: 10,
+        ),
+      ),
+      items: options,
+      onChanged: onChanged,
     );
   }
 }

--- a/lib/features/habits/presentation/screens/home_screen.dart
+++ b/lib/features/habits/presentation/screens/home_screen.dart
@@ -41,17 +41,24 @@ class HomeScreen extends ConsumerWidget {
           onShowActions: (habit) => _showHabitActions(context, ref, habit),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: state.canAddHabit
-            ? () async {
+      floatingActionButton: state.isEmpty
+          ? null
+          : FloatingActionButton(
+              onPressed: () async {
+                if (!state.canAddHabit) {
+                  final message = l10n.habitFormLimitError;
+                  ScaffoldMessenger.of(context)
+                    ..hideCurrentSnackBar()
+                    ..showSnackBar(SnackBar(content: Text(message)));
+                  return;
+                }
                 final result = await context.pushNamed('habit_form');
                 if (!context.mounted) return;
                 _handleFormResult(context, result);
-              }
-            : null,
-        tooltip: l10n.homeAddHabitTooltip,
-        child: const Icon(Icons.add),
-      ),
+              },
+              tooltip: l10n.homeAddHabitTooltip,
+              child: const Icon(Icons.add),
+            ),
     );
   }
 
@@ -155,13 +162,23 @@ class _HomeBody extends StatelessWidget {
     }
 
     if (state.isEmpty) {
-      return ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: [
-          const SizedBox(height: 48),
-          HomeEmptyState(onAdd: () => context.pushNamed('habit_form')),
-          const SizedBox(height: 48),
-        ],
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Center(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 48),
+                  child: HomeEmptyState(
+                    onAdd: () => context.pushNamed('habit_form'),
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
       );
     }
 

--- a/lib/features/habits/presentation/screens/home_screen.dart
+++ b/lib/features/habits/presentation/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:habit_tracker/core/localization/l10n_extensions.dart';
 import 'package:habit_tracker/features/habits/application/habit_form_controller.dart';
+import 'package:habit_tracker/features/habits/application/home_analytics.dart';
 import 'package:habit_tracker/features/habits/application/home_controller.dart';
 import 'package:habit_tracker/features/habits/application/home_state.dart';
 import 'package:habit_tracker/features/habits/presentation/widgets/habit_card.dart';
@@ -18,12 +19,23 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final analytics = ref.read(homeAnalyticsProvider);
+
     ref.listen<HomeState>(homeControllerProvider, (previous, next) {
       if (next.errorMessage != null &&
           next.errorMessage != previous?.errorMessage) {
         ScaffoldMessenger.of(context)
           ..hideCurrentSnackBar()
           ..showSnackBar(SnackBar(content: Text(next.errorMessage!)));
+      }
+
+      final wasLoading = previous?.isLoading ?? true;
+      if (wasLoading && !next.isLoading) {
+        analytics.logView(
+          totalHabits: next.habits.length,
+          completedHabits: next.completedCount,
+          isEmpty: next.isEmpty,
+        );
       }
     });
 
@@ -34,7 +46,10 @@ class HomeScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.homeTodayTitle)),
       body: RefreshIndicator(
-        onRefresh: () => notifier.refresh(),
+        onRefresh: () async {
+          analytics.logRefresh(state);
+          await notifier.refresh();
+        },
         child: _HomeBody(
           state: state,
           onToggleHabit: (habit) => _handleToggle(context, ref, habit),
@@ -46,12 +61,14 @@ class HomeScreen extends ConsumerWidget {
           : FloatingActionButton(
               onPressed: () async {
                 if (!state.canAddHabit) {
+                  analytics.logAddHabitLimitReached(state.habits.length);
                   final message = l10n.habitFormLimitError;
                   ScaffoldMessenger.of(context)
                     ..hideCurrentSnackBar()
                     ..showSnackBar(SnackBar(content: Text(message)));
                   return;
                 }
+                analytics.logAddHabitTap();
                 final result = await context.pushNamed('habit_form');
                 if (!context.mounted) return;
                 _handleFormResult(context, result);
@@ -75,6 +92,9 @@ class HomeScreen extends ConsumerWidget {
       return;
     }
 
+    final analytics = ref.read(homeAnalyticsProvider);
+    analytics.logToggle(habit.habit, result);
+
     final message = result
         ? context.l10n.homeCompletionSnackbar(habit.habit.name)
         : context.l10n.homeUndoSnackbar(habit.habit.name);
@@ -93,6 +113,8 @@ class HomeScreen extends ConsumerWidget {
     WidgetRef ref,
     HomeHabitViewData habit,
   ) async {
+    final analytics = ref.read(homeAnalyticsProvider);
+    analytics.logHabitActionsOpen(habit.habit);
     final action = await showModalBottomSheet<_HabitAction>(
       context: context,
       showDragHandle: true,
@@ -110,6 +132,7 @@ class HomeScreen extends ConsumerWidget {
 
     switch (action) {
       case _HabitAction.edit:
+        analytics.logHabitActionSelected(habit.habit, action: 'edit');
         final result = await context.pushNamed(
           'habit_form',
           extra: habit.habit.id,
@@ -119,6 +142,7 @@ class HomeScreen extends ConsumerWidget {
         break;
       case _HabitAction.undo:
         if (habit.isCompleted) {
+          analytics.logHabitActionSelected(habit.habit, action: 'undo');
           await _handleToggle(context, ref, habit);
         }
         break;

--- a/lib/features/habits/presentation/widgets/habit_day_list.dart
+++ b/lib/features/habits/presentation/widgets/habit_day_list.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/localization/l10n_extensions.dart';
+import '../../application/history_state.dart';
+
+class HabitDayList extends StatelessWidget {
+  const HabitDayList({
+    super.key,
+    required this.date,
+    required this.day,
+    required this.isLoading,
+  });
+
+  final DateTime date;
+  final HistoryDayViewData? day;
+  final bool isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final theme = Theme.of(context);
+    final dateLabel = DateFormat.yMMMMEEEEd(l10n.localeName).format(date);
+    final completed = day?.completedCount ?? 0;
+    final total = day?.totalCount ?? 0;
+    final habits = day?.habits ?? const <HistoryHabitViewData>[];
+    final children = <Widget>[
+      _HistoryDayHeader(
+        dateLabel: dateLabel,
+        summary: l10n.historyCompletionLabel(completed, total),
+      ),
+      const SizedBox(height: 16),
+    ];
+
+    if (isLoading && habits.isEmpty) {
+      children.add(const Center(child: CircularProgressIndicator()));
+    } else if (habits.isEmpty) {
+      children.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 32),
+          child: Text(
+            l10n.historyNoHabitsForDay,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    } else {
+      for (var i = 0; i < habits.length; i += 1) {
+        final habit = habits[i];
+        children.add(_HistoryHabitTile(data: habit));
+        if (i != habits.length - 1) {
+          children.add(const SizedBox(height: 12));
+        }
+      }
+    }
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+      children: children,
+    );
+  }
+}
+
+class _HistoryDayHeader extends StatelessWidget {
+  const _HistoryDayHeader({required this.dateLabel, required this.summary});
+
+  final String dateLabel;
+  final String summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          dateLabel,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          summary,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _HistoryHabitTile extends StatelessWidget {
+  const _HistoryHabitTile({required this.data});
+
+  final HistoryHabitViewData data;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final status = data.status;
+
+    IconData icon;
+    Color color;
+
+    switch (status) {
+      case HistoryHabitStatus.completed:
+        icon = Icons.check_circle;
+        color = Colors.green;
+        break;
+      case HistoryHabitStatus.missed:
+        icon = Icons.cancel_rounded;
+        color = theme.colorScheme.error;
+        break;
+      case HistoryHabitStatus.pending:
+        icon = Icons.schedule_rounded;
+        color = theme.colorScheme.primary;
+        break;
+    }
+
+    return Card(
+      elevation: 0,
+      clipBehavior: Clip.antiAlias,
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+      child: ListTile(
+        leading: Text(data.habit.emoji, style: theme.textTheme.headlineMedium),
+        title: Text(
+          data.habit.name,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        trailing: Icon(icon, color: color),
+      ),
+    );
+  }
+}

--- a/lib/features/habits/presentation/widgets/history_empty_state.dart
+++ b/lib/features/habits/presentation/widgets/history_empty_state.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/localization/l10n_extensions.dart';
+
+class HistoryEmptyState extends StatelessWidget {
+  const HistoryEmptyState({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.calendar_month_outlined,
+              size: 120,
+              color: theme.colorScheme.primary.withValues(alpha: 0.2),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              l10n.historyEmptyTitle,
+              style: theme.textTheme.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              l10n.historyEmptyMessage,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: () => context.goNamed('home'),
+              child: Text(l10n.historyEmptyCta),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/habits/presentation/widgets/week_strip.dart
+++ b/lib/features/habits/presentation/widgets/week_strip.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/utils/date_helpers.dart';
+import '../../application/history_state.dart';
+
+typedef WeekStripSelectCallback = void Function(DateTime date);
+
+class WeekStrip extends StatefulWidget {
+  const WeekStrip({
+    super.key,
+    required this.days,
+    required this.selectedDate,
+    required this.onSelect,
+    this.accentColor,
+  });
+
+  final List<HistoryDayViewData> days;
+  final DateTime selectedDate;
+  final WeekStripSelectCallback onSelect;
+  final Color? accentColor;
+
+  @override
+  State<WeekStrip> createState() => _WeekStripState();
+}
+
+class _WeekStripState extends State<WeekStrip> {
+  late final ScrollController _controller;
+
+  static const double _itemWidth = 72;
+  static const double _itemSpacing = 12;
+  static const double _horizontalPadding = 16;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = ScrollController();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToSelected());
+  }
+
+  @override
+  void didUpdateWidget(covariant WeekStrip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final selectedChanged = !DateHelpers.isSameDay(
+      oldWidget.selectedDate,
+      widget.selectedDate,
+    );
+    if (selectedChanged || oldWidget.days.length != widget.days.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToSelected());
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Color _resolveAccentColor(BuildContext context) {
+    return widget.accentColor ?? Theme.of(context).colorScheme.primary;
+  }
+
+  void _scrollToSelected() {
+    if (!_controller.hasClients || widget.days.isEmpty) {
+      return;
+    }
+    final index = widget.days.indexWhere(
+      (day) => DateHelpers.isSameDay(day.date, widget.selectedDate),
+    );
+    if (index == -1) return;
+
+    final rawOffset = index * (_itemWidth + _itemSpacing);
+    final clampedOffset = rawOffset.clamp(
+      _controller.position.minScrollExtent,
+      _controller.position.maxScrollExtent,
+    );
+    _controller.animateTo(
+      clampedOffset,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _resolveAccentColor(context);
+    final today = DateHelpers.startOfDay(DateTime.now());
+    final dateFormat = DateFormat.Md();
+
+    return SizedBox(
+      height: 100,
+      child: ListView.separated(
+        controller: _controller,
+        padding: const EdgeInsets.symmetric(horizontal: _horizontalPadding),
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (context, index) {
+          final day = widget.days[index];
+          final isSelected = DateHelpers.isSameDay(
+            day.date,
+            widget.selectedDate,
+          );
+          final isToday = DateHelpers.isSameDay(day.date, today);
+          final dayLabel = DateFormat.E().format(day.date).substring(0, 1);
+          final dateLabel = dateFormat.format(day.date);
+
+          return SizedBox(
+            width: _itemWidth,
+            child: _WeekStripItem(
+              label: dayLabel,
+              dateLabel: dateLabel,
+              completionRate: day.completionRate,
+              isSelected: isSelected,
+              isToday: isToday,
+              color: color,
+              onTap: () => widget.onSelect(day.date),
+              hasHabits: day.hasHabits,
+            ),
+          );
+        },
+        separatorBuilder: (context, index) =>
+            const SizedBox(width: _itemSpacing),
+        itemCount: widget.days.length,
+      ),
+    );
+  }
+}
+
+class _WeekStripItem extends StatelessWidget {
+  const _WeekStripItem({
+    required this.label,
+    required this.dateLabel,
+    required this.completionRate,
+    required this.isSelected,
+    required this.isToday,
+    required this.color,
+    required this.onTap,
+    required this.hasHabits,
+  });
+
+  final String label;
+  final String dateLabel;
+  final double completionRate;
+  final bool isSelected;
+  final bool isToday;
+  final Color color;
+  final VoidCallback onTap;
+  final bool hasHabits;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final baseColor = hasHabits ? color : theme.colorScheme.outlineVariant;
+    final textTheme = theme.textTheme;
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            label.toUpperCase(),
+            style: textTheme.labelSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: isSelected
+                  ? theme.colorScheme.onSurface
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Stack(
+            alignment: Alignment.center,
+            children: [
+              SizedBox(
+                width: 44,
+                height: 44,
+                child: CircularProgressIndicator(
+                  value: hasHabits ? completionRate : 0,
+                  strokeWidth: 4,
+                  color: baseColor,
+                  backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                ),
+              ),
+              Container(
+                width: 36,
+                height: 36,
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? baseColor.withValues(alpha: hasHabits ? 0.2 : 0.12)
+                      : theme.colorScheme.surface,
+                  borderRadius: BorderRadius.circular(18),
+                  border: Border.all(
+                    color: isSelected
+                        ? baseColor
+                        : isToday
+                        ? baseColor.withValues(alpha: 0.6)
+                        : theme.dividerColor.withValues(alpha: 0.3),
+                    width: isSelected ? 2 : 1,
+                  ),
+                ),
+                alignment: Alignment.center,
+                child: Text(
+                  dateLabel,
+                  textAlign: TextAlign.center,
+                  style: textTheme.bodySmall?.copyWith(
+                    fontWeight: isSelected ? FontWeight.bold : FontWeight.w500,
+                    color: isSelected
+                        ? baseColor
+                        : theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/application/onboarding_analytics.dart
+++ b/lib/features/onboarding/application/onboarding_analytics.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/services/analytics_service.dart';
+import 'starter_habit_template.dart';
+
+@immutable
+class OnboardingAnalytics {
+  const OnboardingAnalytics();
+
+  Future<void> logPageView(int index) {
+    return AnalyticsService.logEvent(
+      'onboarding_page_view',
+      parameters: {'page_index': index},
+    );
+  }
+
+  Future<void> logGetStartedTap() {
+    return AnalyticsService.logEvent('onboarding_get_started');
+  }
+
+  Future<void> logSkip() {
+    return AnalyticsService.logEvent('onboarding_skip');
+  }
+
+  Future<void> logHabitToggle(
+    StarterHabitTemplate template,
+    String label,
+    bool selected,
+  ) {
+    return AnalyticsService.logEvent(
+      'onboarding_habit_toggle',
+      parameters: {
+        'template_id': template.id,
+        'habit_hash': _hashLabel(label),
+        'selected': selected ? 1 : 0,
+      },
+    );
+  }
+
+  Future<void> logNotificationsRequest({required bool granted}) {
+    return AnalyticsService.logEvent(
+      'onboarding_notifications_request',
+      parameters: {'granted': granted ? 1 : 0},
+    );
+  }
+
+  Future<void> logNotificationsDeclined() {
+    return AnalyticsService.logEvent('onboarding_notifications_decline');
+  }
+
+  Future<void> logComplete({required int selectedCount}) {
+    return AnalyticsService.logEvent(
+      'onboarding_complete',
+      parameters: {'selected_count': selectedCount},
+    );
+  }
+
+  Future<void> logConsentUpdate({
+    required String channel,
+    required bool granted,
+  }) {
+    return AnalyticsService.logEvent(
+      'onboarding_consent_update',
+      parameters: {
+        'channel': channel,
+        'granted': granted ? 1 : 0,
+      },
+    );
+  }
+
+  String _hashLabel(String label) {
+    final digest = sha1.convert(utf8.encode(label));
+    return digest.toString().substring(0, 12);
+  }
+}
+
+final onboardingAnalyticsProvider = Provider<OnboardingAnalytics>((ref) {
+  return const OnboardingAnalytics();
+});

--- a/lib/features/onboarding/application/onboarding_controller.dart
+++ b/lib/features/onboarding/application/onboarding_controller.dart
@@ -8,6 +8,7 @@ import '../../settings/application/providers/notification_settings_provider.dart
 import '../../../core/services/notification_service.dart';
 import '../../../core/telemetry/controllers/telemetry_controller.dart';
 import '../../../core/telemetry/providers/telemetry_provider.dart';
+import 'onboarding_analytics.dart';
 import 'onboarding_state.dart';
 import 'starter_habit_template.dart';
 
@@ -16,6 +17,7 @@ class OnboardingController extends Notifier<OnboardingState> {
   late final NotificationService _notificationService;
   late final NotificationSettingsController _notificationSettings;
   late final TelemetryController _telemetryController;
+  late final OnboardingAnalytics _analytics;
   late final SharedPreferences? _providedPrefs;
 
   static const hasOnboardedKey = 'has_onboarded';
@@ -32,7 +34,13 @@ class OnboardingController extends Notifier<OnboardingState> {
     _notificationService = ref.read(notificationServiceProvider);
     _notificationSettings = ref.read(notificationSettingsProvider.notifier);
     _telemetryController = ref.read(telemetryControllerProvider.notifier);
+    _analytics = ref.read(onboardingAnalyticsProvider);
     _providedPrefs = ref.read(onboardingPreferencesProvider);
+
+    Future<void>.microtask(() {
+      if (!ref.mounted) return;
+      _analytics.logPageView(0);
+    });
 
     return const OnboardingState();
   }
@@ -40,6 +48,7 @@ class OnboardingController extends Notifier<OnboardingState> {
   void setPageIndex(int index) {
     if (index == state.pageIndex) return;
     state = state.copyWith(pageIndex: index);
+    _analytics.logPageView(index);
   }
 
   Future<bool> skipOnboarding() async {
@@ -57,6 +66,8 @@ class OnboardingController extends Notifier<OnboardingState> {
       final prefs = await _prefsInstance();
       await prefs.setBool(hasOnboardedKey, true);
       state = state.copyWith(isSaving: false);
+      _analytics.logSkip();
+      _analytics.logComplete(selectedCount: state.selectedHabits.length);
       return true;
     } catch (error) {
       state = state.copyWith(isSaving: false, errorMessage: error.toString());
@@ -69,25 +80,30 @@ class OnboardingController extends Notifier<OnboardingState> {
     if (current.containsKey(template.id)) {
       current.remove(template.id);
       state = state.copyWith(selectedHabits: current);
+      _analytics.logHabitToggle(template, label, false);
       return;
     }
 
     if (current.length >= 3) {
+      _analytics.logHabitToggle(template, label, false);
       return;
     }
 
     current[template.id] = label;
     state = state.copyWith(selectedHabits: current);
+    _analytics.logHabitToggle(template, label, true);
   }
 
   void setAnalyticsConsent(bool value) {
     if (state.analyticsConsent == value) return;
     state = state.copyWith(analyticsConsent: value);
+    _analytics.logConsentUpdate(channel: 'analytics', granted: value);
   }
 
   void setCrashConsent(bool value) {
     if (state.crashConsent == value) return;
     state = state.copyWith(crashConsent: value);
+    _analytics.logConsentUpdate(channel: 'crash', granted: value);
   }
 
   Future<void> enableNotifications() async {
@@ -103,12 +119,14 @@ class OnboardingController extends Notifier<OnboardingState> {
             : NotificationPermissionStatus.denied,
         isRequestingPermission: false,
       );
+      _analytics.logNotificationsRequest(granted: granted);
     } catch (error) {
       state = state.copyWith(
         errorMessage: error.toString(),
         permissionStatus: NotificationPermissionStatus.denied,
         isRequestingPermission: false,
       );
+      _analytics.logNotificationsRequest(granted: false);
     }
   }
 
@@ -118,6 +136,7 @@ class OnboardingController extends Notifier<OnboardingState> {
       permissionStatus: NotificationPermissionStatus.denied,
       errorMessage: null,
     );
+    _analytics.logNotificationsDeclined();
   }
 
   Future<bool> completeOnboarding() async {
@@ -130,6 +149,7 @@ class OnboardingController extends Notifier<OnboardingState> {
       final prefs = await _prefsInstance();
       await prefs.setBool(hasOnboardedKey, true);
       state = state.copyWith(isSaving: false);
+      _analytics.logComplete(selectedCount: state.selectedHabits.length);
       return true;
     } catch (error) {
       state = state.copyWith(isSaving: false, errorMessage: error.toString());
@@ -166,8 +186,7 @@ class OnboardingController extends Notifier<OnboardingState> {
   }
 
   Future<void> _applyTelemetryConsent() async {
-    await _telemetryController
-        .updateAnalyticsConsent(state.analyticsConsent);
+    await _telemetryController.updateAnalyticsConsent(state.analyticsConsent);
     await _telemetryController.updateCrashConsent(state.crashConsent);
   }
 }

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -6,6 +6,7 @@ import '../../../../core/localization/l10n_extensions.dart';
 import '../../application/onboarding_controller.dart';
 import '../../application/onboarding_state.dart';
 import '../../application/starter_habit_template.dart';
+import '../../application/onboarding_analytics.dart';
 
 class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key});
@@ -114,6 +115,7 @@ class _WelcomePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
     final theme = Theme.of(context);
+    final analytics = ref.read(onboardingAnalyticsProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -134,7 +136,10 @@ class _WelcomePage extends ConsumerWidget {
         ),
         const Spacer(),
         ElevatedButton(
-          onPressed: onGetStarted,
+          onPressed: () {
+            analytics.logGetStartedTap();
+            onGetStarted();
+          },
           child: Text(l10n.onboardingGetStarted),
         ),
         const SizedBox(height: 12),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,6 +76,26 @@
   "navSettingsLabel": "Settings",
   "historyTitle": "History",
   "historyPlaceholder": "Your streak history will appear here soon.",
+  "historyEmptyTitle": "No history yet",
+  "historyEmptyMessage": "Complete your habits to build your timeline.",
+  "historyEmptyCta": "Start tracking today!",
+  "historyFilterLabel": "Filter by habit",
+  "historyFilterAll": "All habits",
+  "historyStreakHeading": "Streak summary",
+  "historyStreakBest": "Best streak",
+  "historyStreakCurrent": "Current streak",
+  "historyCompletionLabel": "{completed} of {total} complete",
+  "@historyCompletionLabel": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "historyNoHabitsForDay": "No scheduled habits for this day.",
   "habitFormCreateTitle": "Create habit",
   "habitFormEditTitle": "Edit habit",
   "habitFormCreatePlaceholder": "The habit form will live here in a future update.",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -174,6 +174,26 @@
   "navSettingsLabel": "Paramètres",
   "historyTitle": "Historique",
   "historyPlaceholder": "Votre historique de séries apparaîtra bientôt ici.",
+  "historyEmptyTitle": "Aucun historique pour le moment",
+  "historyEmptyMessage": "Terminez vos habitudes pour construire votre chronologie.",
+  "historyEmptyCta": "Commencez à suivre aujourd'hui !",
+  "historyFilterLabel": "Filtrer par habitude",
+  "historyFilterAll": "Toutes les habitudes",
+  "historyStreakHeading": "Résumé des séries",
+  "historyStreakBest": "Meilleure série",
+  "historyStreakCurrent": "Série en cours",
+  "historyCompletionLabel": "{completed} sur {total} accomplies",
+  "@historyCompletionLabel": {
+    "placeholders": {
+      "completed": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "historyNoHabitsForDay": "Aucune habitude prévue ce jour-là.",
   "habitFormCreateTitle": "Créer une habitude",
   "habitFormEditTitle": "Modifier une habitude",
   "habitFormCreatePlaceholder": "Le formulaire d'habitudes arrivera dans une prochaine mise à jour.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -236,6 +236,66 @@ abstract class AppLocalizations {
   /// **'Your streak history will appear here soon.'**
   String get historyPlaceholder;
 
+  /// No description provided for @historyEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No history yet'**
+  String get historyEmptyTitle;
+
+  /// No description provided for @historyEmptyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Complete your habits to build your timeline.'**
+  String get historyEmptyMessage;
+
+  /// No description provided for @historyEmptyCta.
+  ///
+  /// In en, this message translates to:
+  /// **'Start tracking today!'**
+  String get historyEmptyCta;
+
+  /// No description provided for @historyFilterLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter by habit'**
+  String get historyFilterLabel;
+
+  /// No description provided for @historyFilterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All habits'**
+  String get historyFilterAll;
+
+  /// No description provided for @historyStreakHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Streak summary'**
+  String get historyStreakHeading;
+
+  /// No description provided for @historyStreakBest.
+  ///
+  /// In en, this message translates to:
+  /// **'Best streak'**
+  String get historyStreakBest;
+
+  /// No description provided for @historyStreakCurrent.
+  ///
+  /// In en, this message translates to:
+  /// **'Current streak'**
+  String get historyStreakCurrent;
+
+  /// No description provided for @historyCompletionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{completed} of {total} complete'**
+  String historyCompletionLabel(int completed, int total);
+
+  /// No description provided for @historyNoHabitsForDay.
+  ///
+  /// In en, this message translates to:
+  /// **'No scheduled habits for this day.'**
+  String get historyNoHabitsForDay;
+
   /// No description provided for @habitFormCreateTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -93,6 +93,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String get historyPlaceholder => 'Your streak history will appear here soon.';
 
   @override
+  String get historyEmptyTitle => 'No history yet';
+
+  @override
+  String get historyEmptyMessage =>
+      'Complete your habits to build your timeline.';
+
+  @override
+  String get historyEmptyCta => 'Start tracking today!';
+
+  @override
+  String get historyFilterLabel => 'Filter by habit';
+
+  @override
+  String get historyFilterAll => 'All habits';
+
+  @override
+  String get historyStreakHeading => 'Streak summary';
+
+  @override
+  String get historyStreakBest => 'Best streak';
+
+  @override
+  String get historyStreakCurrent => 'Current streak';
+
+  @override
+  String historyCompletionLabel(int completed, int total) {
+    return '$completed of $total complete';
+  }
+
+  @override
+  String get historyNoHabitsForDay => 'No scheduled habits for this day.';
+
+  @override
   String get habitFormCreateTitle => 'Create habit';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -94,6 +94,39 @@ class AppLocalizationsFr extends AppLocalizations {
       'Votre historique de séries apparaîtra bientôt ici.';
 
   @override
+  String get historyEmptyTitle => 'Aucun historique pour le moment';
+
+  @override
+  String get historyEmptyMessage =>
+      'Terminez vos habitudes pour construire votre chronologie.';
+
+  @override
+  String get historyEmptyCta => 'Commencez à suivre aujourd\'hui !';
+
+  @override
+  String get historyFilterLabel => 'Filtrer par habitude';
+
+  @override
+  String get historyFilterAll => 'Toutes les habitudes';
+
+  @override
+  String get historyStreakHeading => 'Résumé des séries';
+
+  @override
+  String get historyStreakBest => 'Meilleure série';
+
+  @override
+  String get historyStreakCurrent => 'Série en cours';
+
+  @override
+  String historyCompletionLabel(int completed, int total) {
+    return '$completed sur $total accomplies';
+  }
+
+  @override
+  String get historyNoHabitsForDay => 'Aucune habitude prévue ce jour-là.';
+
+  @override
   String get habitFormCreateTitle => 'Créer une habitude';
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -438,7 +438,7 @@ packages:
     source: hosted
     version: "4.5.4"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   crypto: ^3.0.5
   uuid: ^4.5.1
   timezone: ^0.10.1
+  intl: ^0.20.2
 
 dev_dependencies:
   flutter_test:

--- a/test/features/habits/application/habit_form_controller_test.dart
+++ b/test/features/habits/application/habit_form_controller_test.dart
@@ -115,10 +115,12 @@ void main() {
     when(() => habitsRepository.countHabits()).thenAnswer((_) async => 0);
     when(() => habitsRepository.saveHabit(any())).thenAnswer((_) async {});
     when(() => habitsRepository.findById(any())).thenAnswer((_) async => null);
-    when(() => habitEntriesRepository.deleteEntriesForHabit(any()))
-        .thenAnswer((_) async {});
-    when(() => notificationService.cancelHabitReminder(any()))
-        .thenAnswer((_) async {});
+    when(
+      () => habitEntriesRepository.deleteEntriesForHabit(any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => notificationService.cancelHabitReminder(any()),
+    ).thenAnswer((_) async {});
     when(
       () => notificationService.scheduleHabitReminder(
         habitId: any(named: 'habitId'),
@@ -128,8 +130,9 @@ void main() {
         time: any(named: 'time'),
       ),
     ).thenAnswer((_) async {});
-    when(() => notificationService.requestPermission())
-        .thenAnswer((_) async => true);
+    when(
+      () => notificationService.requestPermission(),
+    ).thenAnswer((_) async => true);
 
     container = ProviderContainer(
       overrides: [
@@ -184,8 +187,9 @@ void main() {
   });
 
   test('submit returns limit reached when at max habits', () async {
-    when(() => habitsRepository.countHabits())
-        .thenAnswer((_) async => HabitsRepository.maxHabitsPerDay);
+    when(
+      () => habitsRepository.countHabits(),
+    ).thenAnswer((_) async => HabitsRepository.maxHabitsPerDay);
     final controller = buildController();
 
     controller.setName('Drink water');
@@ -233,8 +237,9 @@ void main() {
       bestStreak: 0,
       currentStreak: 0,
     );
-    when(() => habitsRepository.findById('habit-1'))
-        .thenAnswer((_) async => habit);
+    when(
+      () => habitsRepository.findById('habit-1'),
+    ).thenAnswer((_) async => habit);
 
     final controller = buildController(habitId: habit.id);
     await settle();
@@ -246,15 +251,18 @@ void main() {
 
     expect(result.status, HabitFormSaveStatus.success);
     expect(result.isNew, isFalse);
-    verify(() => notificationService.cancelHabitReminder(habit.reminderId))
-        .called(1);
-    verify(() => notificationService.scheduleHabitReminder(
-          habitId: habit.reminderId,
-          title: any(named: 'title'),
-          body: any(named: 'body'),
-          days: any(named: 'days'),
-          time: any(named: 'time'),
-        )).called(1);
+    verify(
+      () => notificationService.cancelHabitReminder(habit.reminderId),
+    ).called(1);
+    verify(
+      () => notificationService.scheduleHabitReminder(
+        habitId: habit.reminderId,
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        days: any(named: 'days'),
+        time: any(named: 'time'),
+      ),
+    ).called(1);
   });
 
   test('deleteHabit cancels scheduled notifications', () async {
@@ -273,8 +281,9 @@ void main() {
     final deleteResult = await controller.deleteHabit();
 
     expect(deleteResult.status, HabitFormDeleteStatus.deleted);
-    verify(() => notificationService.cancelHabitReminder(result.habit!.reminderId))
-        .called(1);
+    verify(
+      () => notificationService.cancelHabitReminder(result.habit!.reminderId),
+    ).called(1);
   });
 
   test('hasChanges flag resets after successful save', () async {

--- a/test/features/habits/application/history_controller_test.dart
+++ b/test/features/habits/application/history_controller_test.dart
@@ -1,0 +1,340 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:habit_tracker/features/habits/application/history_analytics.dart';
+import 'package:habit_tracker/features/habits/application/history_controller.dart';
+import 'package:habit_tracker/features/habits/application/history_state.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habit_entries_repository.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
+import 'package:habit_tracker/features/habits/domain/domain.dart';
+import 'package:habit_tracker/features/habits/domain/usecases/get_habit_history.dart';
+
+class _MockGetHabitHistory extends Mock implements GetHabitHistory {}
+
+class _MockHabitsRepository extends Mock implements HabitsRepository {}
+
+class _MockHabitEntriesRepository extends Mock
+    implements HabitEntriesRepository {}
+
+class _Counter {
+  int value = 0;
+  void increment() => value += 1;
+}
+
+class _RecordingHistoryAnalytics extends HistoryAnalytics {
+  _RecordingHistoryAnalytics()
+    : _viewCalls = _Counter(),
+      _emptyStateCalls = _Counter(),
+      _streakCalls = _Counter();
+
+  final _Counter _viewCalls;
+  final _Counter _emptyStateCalls;
+  final _Counter _streakCalls;
+  final List<Map<String, Object?>> daySelectEvents = [];
+  final List<String> filterHabitIds = [];
+  final List<Map<String, Object?>> scrollEvents = [];
+
+  int get viewCalls => _viewCalls.value;
+  int get emptyStateCalls => _emptyStateCalls.value;
+  int get streakCalls => _streakCalls.value;
+
+  @override
+  Future<void> logView({
+    required int dateRangeDays,
+    required int totalHabits,
+  }) async {
+    _viewCalls.increment();
+  }
+
+  @override
+  Future<void> logEmptyState({required int totalHabits}) async {
+    _emptyStateCalls.increment();
+  }
+
+  @override
+  Future<void> logDaySelect({
+    required DateTime date,
+    required double completionRate,
+    int? streakOnDate,
+  }) async {
+    daySelectEvents.add({
+      'date': date,
+      'rate': completionRate,
+      'streak': streakOnDate,
+    });
+  }
+
+  @override
+  Future<void> logFilterToggle(Habit habit) async {
+    filterHabitIds.add(habit.id);
+  }
+
+  @override
+  Future<void> logScrollRange({
+    required int daysLoaded,
+    required String direction,
+  }) async {
+    scrollEvents.add({'days': daysLoaded, 'direction': direction});
+  }
+
+  @override
+  Future<void> logStreakSummary({
+    required int bestStreak,
+    required int currentStreak,
+  }) async {
+    _streakCalls.increment();
+  }
+}
+
+class _NoopTimer implements Timer {
+  _NoopTimer();
+
+  @override
+  void cancel() {}
+
+  @override
+  bool get isActive => false;
+
+  @override
+  int get tick => 0;
+}
+
+void main() {
+  late ProviderContainer container;
+  late ProviderSubscription<HistoryState> subscription;
+  late _MockGetHabitHistory getHabitHistory;
+  late _MockHabitsRepository habitsRepository;
+  late _MockHabitEntriesRepository entriesRepository;
+  late _RecordingHistoryAnalytics analytics;
+  late Habit habit;
+  late Habit otherHabit;
+  late HabitHistorySnapshot allSnapshot;
+  late HabitHistorySnapshot filteredSnapshot;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2024));
+  });
+
+  setUp(() {
+    getHabitHistory = _MockGetHabitHistory();
+    habitsRepository = _MockHabitsRepository();
+    entriesRepository = _MockHabitEntriesRepository();
+    analytics = _RecordingHistoryAnalytics();
+
+    habit = Habit(
+      id: 'habit-1',
+      name: 'Read',
+      emoji: '📚',
+      color: 0xFF7C3AED,
+      days: const [0, 1, 2, 3, 4, 5, 6],
+      reminderId: '',
+      reminderTime: '',
+      bestStreak: 4,
+      currentStreak: 2,
+      createdAt: DateTime(2024, 6, 9),
+    );
+
+    otherHabit = Habit(
+      id: 'habit-2',
+      name: 'Meditate',
+      emoji: '🧘',
+      color: 0xFF22C55E,
+      days: const [0, 2, 4],
+      reminderId: 'reminder-2',
+      reminderTime: '08:00',
+      bestStreak: 1,
+      currentStreak: 0,
+      createdAt: DateTime(2024, 6, 8),
+    );
+
+    final date = DateTime(2024, 6, 10);
+    final prior = date.subtract(const Duration(days: 1));
+
+    allSnapshot = HabitHistorySnapshot(
+      rangeStart: prior,
+      rangeEnd: date,
+      days: [
+        HabitHistoryDay(
+          date: prior,
+          items: [
+            HabitHistoryItem(
+              habit: habit,
+              date: prior,
+              entry: HabitEntry(habitId: habit.id, date: prior, done: true),
+            ),
+            HabitHistoryItem(habit: otherHabit, date: prior, entry: null),
+          ],
+        ),
+        HabitHistoryDay(
+          date: date,
+          items: [
+            HabitHistoryItem(habit: habit, date: date, entry: null),
+            HabitHistoryItem(habit: otherHabit, date: date, entry: null),
+          ],
+        ),
+      ],
+      habits: [habit, otherHabit],
+    );
+
+    filteredSnapshot = HabitHistorySnapshot(
+      rangeStart: prior,
+      rangeEnd: date,
+      days: [
+        HabitHistoryDay(
+          date: prior,
+          items: [
+            HabitHistoryItem(
+              habit: habit,
+              date: prior,
+              entry: HabitEntry(habitId: habit.id, date: prior, done: true),
+            ),
+          ],
+        ),
+        HabitHistoryDay(
+          date: date,
+          items: [HabitHistoryItem(habit: habit, date: date, entry: null)],
+        ),
+      ],
+      habits: [habit, otherHabit],
+    );
+
+    when(
+      () => habitsRepository.watchHabits(),
+    ).thenAnswer((_) => const Stream<List<Habit>>.empty());
+    when(
+      () => entriesRepository.watchEntriesInRange(
+        any(),
+        any(),
+        habitId: any(named: 'habitId'),
+      ),
+    ).thenAnswer((_) => const Stream<List<HabitEntry>>.empty());
+    when(
+      () => getHabitHistory(
+        startDate: any(named: 'startDate'),
+        endDate: any(named: 'endDate'),
+        habitId: any(named: 'habitId'),
+      ),
+    ).thenAnswer((invocation) async {
+      final filter = invocation.namedArguments[#habitId] as String?;
+      if (filter == habit.id) {
+        return filteredSnapshot;
+      }
+      return allSnapshot;
+    });
+
+    container = ProviderContainer(
+      overrides: [
+        getHabitHistoryProvider.overrideWithValue(getHabitHistory),
+        historyAnalyticsProvider.overrideWithValue(analytics),
+        habitsRepositoryProvider.overrideWithValue(habitsRepository),
+        habitEntriesRepositoryProvider.overrideWithValue(entriesRepository),
+        historyControllerClockProvider.overrideWithValue(
+          () => DateTime(2024, 6, 10),
+        ),
+        historyControllerTimerProvider.overrideWithValue(
+          (duration, callback) => _NoopTimer(),
+        ),
+      ],
+    );
+    subscription = container.listen(
+      historyControllerProvider,
+      (previous, next) {},
+      fireImmediately: true,
+    );
+  });
+
+  tearDown(() {
+    subscription.close();
+    container.dispose();
+  });
+
+  Future<void> pumpController() async {
+    container.read(historyControllerProvider);
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+  }
+
+  HistoryController controller() =>
+      container.read(historyControllerProvider.notifier);
+
+  HistoryState state() => container.read(historyControllerProvider);
+  Future<HistoryState> waitFor(bool Function(HistoryState) matcher) async {
+    for (var i = 0; i < 50; i += 1) {
+      final current = state();
+      if (matcher(current)) {
+        return current;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    throw StateError(
+      'HistoryController state did not reach expected condition',
+    );
+  }
+
+  test('initial load populates history and logs view', () async {
+    await pumpController();
+
+    final current = await waitFor((value) => value.days.isNotEmpty);
+    expect(current.days, isNotEmpty);
+    expect(current.selectedDate, allSnapshot.rangeEnd);
+    final today = allSnapshot.rangeEnd;
+    final todayDay = current.dayFor(today);
+    expect(todayDay?.habits.length, 2);
+    expect(current.streakSummary.bestStreak, habit.bestStreak);
+    expect(analytics.viewCalls, 1);
+    expect(analytics.streakCalls, 1);
+  });
+
+  test('selectDate updates state and logs analytics', () async {
+    await pumpController();
+
+    final previous = allSnapshot.days.first.date;
+    await controller().selectDate(previous);
+
+    final current = await waitFor((value) => value.selectedDate == previous);
+    expect(current.selectedDate, previous);
+    expect(analytics.daySelectEvents, isNotEmpty);
+    final event = analytics.daySelectEvents.last;
+    expect(event['date'], previous);
+  });
+
+  test('applyHabitFilter updates filter and logs event', () async {
+    await pumpController();
+
+    await controller().applyHabitFilter(habit.id);
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+
+    final current = await waitFor((value) => value.filterHabitId == habit.id);
+    expect(current.filterHabitId, habit.id);
+    final firstDay = current.days.first;
+    expect(firstDay.habits.length, 1);
+    expect(analytics.filterHabitIds, contains(habit.id));
+  });
+
+  test('applyHabitFilter resets to all habits when selecting null', () async {
+    await pumpController();
+
+    await controller().applyHabitFilter(habit.id);
+    await waitFor((value) => value.filterHabitId == habit.id);
+
+    await controller().applyHabitFilter(null);
+    final current = await waitFor((value) => value.filterHabitId == null);
+
+    final today = allSnapshot.rangeEnd;
+    final day = current.dayFor(today);
+    expect(day?.habits.length, 2);
+  });
+
+  test('reportScroll logs only once per direction', () async {
+    await pumpController();
+
+    await controller().reportScroll(HistoryScrollDirection.backward);
+    await controller().reportScroll(HistoryScrollDirection.backward);
+
+    expect(analytics.scrollEvents.length, 1);
+    expect(analytics.scrollEvents.first['direction'], 'backward');
+  });
+}

--- a/test/features/habits/application/home_controller_test.dart
+++ b/test/features/habits/application/home_controller_test.dart
@@ -52,14 +52,18 @@ void main() {
       currentStreak: 0,
     );
 
-    when(() => habitsRepository.getTodayHabits(any()))
-        .thenAnswer((_) async => [habit]);
-    when(() => habitsRepository.watchTodayHabits(any()))
-        .thenAnswer((_) => habitsStream.stream);
-    when(() => habitEntriesRepository.fetchEntriesForDate(any()))
-        .thenAnswer((_) async => <HabitEntry>[]);
-    when(() => habitEntriesRepository.watchEntriesForDate(any()))
-        .thenAnswer((_) => entriesStream.stream);
+    when(
+      () => habitsRepository.getTodayHabits(any()),
+    ).thenAnswer((_) async => [habit]);
+    when(
+      () => habitsRepository.watchTodayHabits(any()),
+    ).thenAnswer((_) => habitsStream.stream);
+    when(
+      () => habitEntriesRepository.fetchEntriesForDate(any()),
+    ).thenAnswer((_) async => <HabitEntry>[]);
+    when(
+      () => habitEntriesRepository.watchEntriesForDate(any()),
+    ).thenAnswer((_) => entriesStream.stream);
 
     container = ProviderContainer(
       overrides: [
@@ -76,7 +80,10 @@ void main() {
         ),
       ],
     );
-    subscription = container.listen(homeControllerProvider, (previous, next) {});
+    subscription = container.listen(
+      homeControllerProvider,
+      (previous, next) {},
+    );
   });
 
   tearDown(() async {
@@ -86,7 +93,8 @@ void main() {
     container.dispose();
   });
 
-  HomeController controller() => container.read(homeControllerProvider.notifier);
+  HomeController controller() =>
+      container.read(homeControllerProvider.notifier);
 
   Future<void> pumpMicrotasks() => Future<void>.delayed(Duration.zero);
 
@@ -113,7 +121,6 @@ void main() {
     expect(state.isLoading, isFalse);
     expect(state.habits, isNotEmpty);
     expect(state.habits.first.habit, habit);
-
   });
 
   test('toggleHabit updates completion state and streaks', () async {
@@ -131,23 +138,22 @@ void main() {
       done: true,
     );
 
-    when(() => toggleHabitCompletion.call(
-          habitId: habit.id,
-          date: any(named: 'date'),
-        )).thenAnswer(
+    when(
+      () => toggleHabitCompletion.call(
+        habitId: habit.id,
+        date: any(named: 'date'),
+      ),
+    ).thenAnswer(
       (_) async => ToggleHabitResult(habit: updatedHabit, entry: entry),
     );
 
     final result = await ctrl.toggleHabit(habit.id);
     expect(result, isTrue);
 
-    final state = await waitForState(
-      (value) => value.habits.first.isCompleted,
-    );
+    final state = await waitForState((value) => value.habits.first.isCompleted);
     expect(state.completedCount, 1);
     expect(state.habits.first.habit.currentStreak, 1);
     expect(state.habits.first.isCompleted, isTrue);
-
   });
 
   test('toggleHabit restores previous state when failing', () async {
@@ -158,19 +164,18 @@ void main() {
 
     await waitForState((value) => !value.isLoading);
 
-    when(() => toggleHabitCompletion.call(
-          habitId: habit.id,
-          date: any(named: 'date'),
-        )).thenThrow(Exception('failure'));
+    when(
+      () => toggleHabitCompletion.call(
+        habitId: habit.id,
+        date: any(named: 'date'),
+      ),
+    ).thenThrow(Exception('failure'));
 
     final result = await ctrl.toggleHabit(habit.id);
 
     expect(result, isNull);
-    final state = await waitForState(
-      (value) => value.errorMessage != null,
-    );
+    final state = await waitForState((value) => value.errorMessage != null);
     expect(state.habits.first.isCompleted, isFalse);
     expect(state.errorMessage, contains('failure'));
-
   });
 }

--- a/test/features/habits/domain/usecases/get_habit_history_test.dart
+++ b/test/features/habits/domain/usecases/get_habit_history_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:habit_tracker/features/habits/data/repositories/habit_entries_repository.dart';
+import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
+import 'package:habit_tracker/features/habits/domain/domain.dart';
+import 'package:habit_tracker/features/habits/domain/usecases/get_habit_history.dart';
+
+class _MockHabitsRepository extends Mock implements HabitsRepository {}
+
+class _MockHabitEntriesRepository extends Mock
+    implements HabitEntriesRepository {}
+
+void main() {
+  late _MockHabitsRepository habitsRepository;
+  late _MockHabitEntriesRepository entriesRepository;
+  late GetHabitHistory usecase;
+  late Habit habitA;
+  late Habit habitB;
+  late HabitEntry entryA;
+
+  setUpAll(() {
+    registerFallbackValue(DateTime(2024));
+  });
+
+  setUp(() {
+    habitsRepository = _MockHabitsRepository();
+    entriesRepository = _MockHabitEntriesRepository();
+    usecase = GetHabitHistory(
+      habitsRepository: habitsRepository,
+      entriesRepository: entriesRepository,
+    );
+
+    habitA = Habit(
+      id: 'habit-a',
+      name: 'Read',
+      emoji: '📚',
+      color: 0xFF4F46E5,
+      days: const [0, 1, 2, 3, 4, 5, 6],
+      reminderId: '',
+      reminderTime: '',
+      bestStreak: 5,
+      currentStreak: 2,
+      createdAt: DateTime(2024, 6, 5),
+    );
+    habitB = Habit(
+      id: 'habit-b',
+      name: 'Meditate',
+      emoji: '🧘',
+      color: 0xFF22C55E,
+      days: const [0, 2, 4],
+      reminderId: '',
+      reminderTime: '',
+      bestStreak: 3,
+      currentStreak: 1,
+      createdAt: DateTime(2024, 6, 10),
+    );
+
+    entryA = HabitEntry(
+      habitId: habitA.id,
+      date: DateTime(2024, 6, 10),
+      done: true,
+    );
+  });
+
+  test('builds history snapshot for given range', () async {
+    when(
+      () => habitsRepository.fetchHabits(),
+    ).thenAnswer((_) async => [habitA, habitB]);
+    when(
+      () => entriesRepository.fetchEntriesInRange(
+        any(),
+        any(),
+        habitId: any(named: 'habitId'),
+      ),
+    ).thenAnswer((_) async => [entryA]);
+
+    final snapshot = await usecase(
+      startDate: DateTime(2024, 6, 9),
+      endDate: DateTime(2024, 6, 11),
+    );
+
+    expect(snapshot.rangeStart, DateTime(2024, 6, 9));
+    expect(snapshot.rangeEnd, DateTime(2024, 6, 11));
+    expect(snapshot.days.length, 3);
+    final targetDay = snapshot.days.firstWhere(
+      (day) => day.date == DateTime(2024, 6, 10),
+    );
+    expect(targetDay.items.length, 2);
+    final completed = targetDay.items
+        .where((item) => item.isCompleted)
+        .toList();
+    expect(completed.length, 1);
+    expect(completed.first.habit.id, habitA.id);
+
+    final beforeCreation = snapshot.days.firstWhere(
+      (day) => day.date == DateTime(2024, 6, 9),
+    );
+    expect(beforeCreation.items.length, 1);
+    expect(beforeCreation.items.single.habit.id, habitA.id);
+  });
+
+  test('filters snapshot when habitId provided', () async {
+    when(
+      () => habitsRepository.fetchHabits(),
+    ).thenAnswer((_) async => [habitA, habitB]);
+    when(
+      () => entriesRepository.fetchEntriesInRange(
+        any(),
+        any(),
+        habitId: any(named: 'habitId'),
+      ),
+    ).thenAnswer((invocation) async {
+      final habitId = invocation.namedArguments[#habitId] as String?;
+      if (habitId == habitA.id) return [entryA];
+      return const <HabitEntry>[];
+    });
+
+    final snapshot = await usecase(
+      startDate: DateTime(2024, 6, 9),
+      endDate: DateTime(2024, 6, 11),
+      habitId: habitA.id,
+    );
+
+    expect(snapshot.days.length, 3);
+    for (final day in snapshot.days) {
+      expect(day.items.length, lessThanOrEqualTo(1));
+      if (day.date == DateTime(2024, 6, 10)) {
+        expect(day.items.single.isCompleted, isTrue);
+      }
+    }
+  });
+
+  test('excludes habits from days before they were created', () async {
+    when(
+      () => habitsRepository.fetchHabits(),
+    ).thenAnswer((_) async => [habitA, habitB]);
+    when(
+      () => entriesRepository.fetchEntriesInRange(
+        any(),
+        any(),
+        habitId: any(named: 'habitId'),
+      ),
+    ).thenAnswer((_) async => const <HabitEntry>[]);
+
+    final snapshot = await usecase(
+      startDate: DateTime(2024, 6, 8),
+      endDate: DateTime(2024, 6, 11),
+    );
+
+    final beforeCreation = snapshot.days.firstWhere(
+      (day) => day.date == DateTime(2024, 6, 8),
+    );
+    expect(beforeCreation.items.length, 1);
+    expect(beforeCreation.items.single.habit.id, habitA.id);
+
+    final creationDay = snapshot.days.firstWhere(
+      (day) => day.date == DateTime(2024, 6, 10),
+    );
+    expect(
+      creationDay.items.map((item) => item.habit.id),
+      containsAll([habitA.id, habitB.id]),
+    );
+  });
+}

--- a/test/features/habits/presentation/screens/history_screen_test.dart
+++ b/test/features/habits/presentation/screens/history_screen_test.dart
@@ -1,25 +1,118 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:habit_tracker/features/habits/application/history_controller.dart';
+import 'package:habit_tracker/features/habits/application/history_state.dart';
+import 'package:habit_tracker/features/habits/domain/domain.dart';
 import 'package:habit_tracker/features/habits/presentation/screens/history_screen.dart';
 import 'package:habit_tracker/l10n/app_localizations.dart';
 
 void main() {
-  testWidgets('renders history placeholder copy', (tester) async {
+  final baseDate = DateTime(2024, 6, 10);
+
+  HistoryState emptyState() {
+    return HistoryState(
+      rangeStart: baseDate.subtract(const Duration(days: 29)),
+      rangeEnd: baseDate,
+      selectedDate: baseDate,
+      days: const [],
+      habits: const [],
+      isLoading: false,
+    );
+  }
+
+  HistoryState populatedState() {
+    final habitView = HistoryHabitViewData(
+      habit: HabitStub('habit-1', 'Read', '📚', 0xFF4F46E5),
+      date: baseDate,
+      status: HistoryHabitStatus.completed,
+    );
+    return HistoryState(
+      rangeStart: baseDate.subtract(const Duration(days: 1)),
+      rangeEnd: baseDate,
+      selectedDate: baseDate,
+      days: [
+        HistoryDayViewData(date: baseDate, habits: [habitView]),
+      ],
+      habits: [habitView.habit],
+      isLoading: false,
+      streakSummary: const HistoryStreakSummary(
+        bestStreak: 5,
+        currentStreak: 2,
+      ),
+    );
+  }
+
+  testWidgets('shows empty state when no history exists', (tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: const HistoryScreen(),
+      ProviderScope(
+        overrides: [
+          historyControllerProvider.overrideWith(
+            () => _StaticHistoryController(emptyState()),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const HistoryScreen(),
+        ),
       ),
     );
 
-    expect(
-      find.descendant(of: find.byType(AppBar), matching: find.text('History')),
-      findsOneWidget,
-    );
-    expect(
-      find.text('Your streak history will appear here soon.'),
-      findsOneWidget,
-    );
+    expect(find.text('History'), findsOneWidget);
+    expect(find.text('No history yet'), findsOneWidget);
+    expect(find.text('Start tracking today!'), findsOneWidget);
   });
+
+  testWidgets('renders summary and habit day list when data present', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          historyControllerProvider.overrideWith(
+            () => _StaticHistoryController(populatedState()),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const HistoryScreen(),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Streak summary'), findsOneWidget);
+    expect(find.text('5'), findsOneWidget);
+    expect(find.text('2'), findsOneWidget);
+    expect(find.textContaining('Read'), findsWidgets);
+  });
+}
+
+class HabitStub extends Habit {
+  HabitStub(String id, String name, String emoji, int color)
+    : super(
+        id: id,
+        name: name,
+        emoji: emoji,
+        color: color,
+        days: const [0, 1, 2, 3, 4, 5, 6],
+        reminderId: '',
+        reminderTime: '',
+        bestStreak: 0,
+        currentStreak: 0,
+        createdAt: DateTime(2024, 6, 1),
+      );
+}
+
+class _StaticHistoryController extends HistoryController {
+  _StaticHistoryController(this._state) : super();
+
+  final HistoryState _state;
+
+  @override
+  HistoryState build() => _state;
 }

--- a/test/features/habits/presentation/screens/home_screen_test.dart
+++ b/test/features/habits/presentation/screens/home_screen_test.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:habit_tracker/features/habits/application/home_analytics.dart';
 import 'package:habit_tracker/features/habits/application/home_controller.dart';
+import 'package:habit_tracker/features/habits/application/home_state.dart';
 import 'package:habit_tracker/features/habits/data/repositories/habit_entries_repository.dart';
 import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
 import 'package:habit_tracker/features/habits/domain/domain.dart';
@@ -20,6 +22,38 @@ class _MockHabitEntriesRepository extends Mock
 
 class _MockToggleHabitCompletion extends Mock
     implements ToggleHabitCompletion {}
+
+class _StubHomeAnalytics extends HomeAnalytics {
+  const _StubHomeAnalytics();
+
+  @override
+  Future<void> logView({
+    required int totalHabits,
+    required int completedHabits,
+    required bool isEmpty,
+  }) async {}
+
+  @override
+  Future<void> logToggle(Habit habit, bool completed) async {}
+
+  @override
+  Future<void> logRefresh(HomeState state) async {}
+
+  @override
+  Future<void> logAddHabitTap() async {}
+
+  @override
+  Future<void> logAddHabitLimitReached(int totalHabits) async {}
+
+  @override
+  Future<void> logHabitActionsOpen(Habit habit) async {}
+
+  @override
+  Future<void> logHabitActionSelected(
+    Habit habit, {
+    required String action,
+  }) async {}
+}
 
 GoRouter _createRouter() {
   final rootKey = GlobalKey<NavigatorState>();
@@ -116,7 +150,10 @@ void main() {
   Future<void> pumpHome(WidgetTester tester, HomeController controller) async {
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [homeControllerProvider.overrideWith(() => controller)],
+        overrides: [
+          homeControllerProvider.overrideWith(() => controller),
+          homeAnalyticsProvider.overrideWithValue(const _StubHomeAnalytics()),
+        ],
         child: MaterialApp.router(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/test/features/onboarding/application/onboarding_controller_test.dart
+++ b/test/features/onboarding/application/onboarding_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:habit_tracker/core/telemetry/controllers/telemetry_controller.da
 import 'package:habit_tracker/core/telemetry/providers/telemetry_provider.dart';
 import 'package:habit_tracker/features/habits/data/repositories/habits_repository.dart';
 import 'package:habit_tracker/features/habits/domain/entities/habit.dart';
+import 'package:habit_tracker/features/onboarding/application/onboarding_analytics.dart';
 import 'package:habit_tracker/features/onboarding/application/onboarding_controller.dart';
 import 'package:habit_tracker/features/onboarding/application/onboarding_state.dart';
 import 'package:habit_tracker/features/onboarding/application/starter_habit_template.dart';
@@ -18,6 +19,41 @@ import 'package:habit_tracker/features/settings/application/providers/notificati
 class _MockHabitsRepository extends Mock implements HabitsRepository {}
 
 class _MockNotificationService extends Mock implements NotificationService {}
+
+class _StubOnboardingAnalytics extends OnboardingAnalytics {
+  const _StubOnboardingAnalytics();
+
+  @override
+  Future<void> logPageView(int index) async {}
+
+  @override
+  Future<void> logGetStartedTap() async {}
+
+  @override
+  Future<void> logSkip() async {}
+
+  @override
+  Future<void> logHabitToggle(
+    StarterHabitTemplate template,
+    String label,
+    bool selected,
+  ) async {}
+
+  @override
+  Future<void> logNotificationsRequest({required bool granted}) async {}
+
+  @override
+  Future<void> logNotificationsDeclined() async {}
+
+  @override
+  Future<void> logComplete({required int selectedCount}) async {}
+
+  @override
+  Future<void> logConsentUpdate({
+    required String channel,
+    required bool granted,
+  }) async {}
+}
 
 void main() {
   late ProviderContainer container;
@@ -50,8 +86,9 @@ void main() {
     notificationService = _MockNotificationService();
 
     when(() => habitsRepository.saveHabit(any())).thenAnswer((_) async {});
-    when(() => notificationService.requestPermission())
-        .thenAnswer((_) async => true);
+    when(
+      () => notificationService.requestPermission(),
+    ).thenAnswer((_) async => true);
 
     container = ProviderContainer(
       overrides: [
@@ -65,13 +102,14 @@ void main() {
         ),
         telemetryControllerProvider.overrideWith(TelemetryController.new),
         onboardingPreferencesProvider.overrideWithValue(prefs),
+        onboardingAnalyticsProvider.overrideWithValue(
+          const _StubOnboardingAnalytics(),
+        ),
       ],
     );
 
     await container.read(telemetryControllerProvider.notifier).initialize();
-    await container
-        .read(notificationSettingsProvider.notifier)
-        .load();
+    await container.read(notificationSettingsProvider.notifier).load();
   });
 
   tearDown(() {
@@ -128,8 +166,9 @@ void main() {
   });
 
   test('handles platform denial when enabling reminders', () async {
-    when(() => notificationService.requestPermission())
-        .thenAnswer((_) async => false);
+    when(
+      () => notificationService.requestPermission(),
+    ).thenAnswer((_) async => false);
     final ctrl = controller();
 
     await ctrl.enableNotifications();


### PR DESCRIPTION
## Summary
- implement history screen with creation-aware filtering, week strip, and telemetry
- instrument home, habit form, and onboarding flows with analytics events
- update tests, localization, and repositories to support new data and UI states

## Testing
- fvm flutter analyze
- fvm flutter test